### PR TITLE
Various fixes to incoming webhooks for withings/fitbit notifications

### DIFF
--- a/slackhealthbot/main.py
+++ b/slackhealthbot/main.py
@@ -139,7 +139,7 @@ async def fitbit_notification_webhook(
         else:
             if sleep_data:
                 last_sleep_data = svc_models.user_last_sleep_data(user.fitbit)
-                save_new_sleep_data(db, user, sleep_data)
+                await save_new_sleep_data(db, user, sleep_data)
                 await slack.post_sleep(
                     slack_alias=user.slack_alias,
                     new_sleep_data=sleep_data,

--- a/tests/fixtures/fitbit_scenarios.py
+++ b/tests/fixtures/fitbit_scenarios.py
@@ -1,0 +1,248 @@
+import dataclasses
+import datetime
+from typing import Any
+
+from slackhealthbot.services.models import SleepData
+
+
+@dataclasses.dataclass
+class FitbitTestScenario:
+    input_initial_sleep_data: dict[str, int]
+    input_mock_fitbit_response: dict[str, Any]
+    expected_new_last_sleep_data: SleepData
+    expected_icons: str
+
+
+scenarios: dict[str, FitbitTestScenario] = {
+    "No previous sleep data": FitbitTestScenario(
+        # No previous sleep data
+        input_initial_sleep_data={
+            "last_sleep_start_time": None,
+            "last_sleep_end_time": None,
+            "last_sleep_sleep_minutes": None,
+            "last_sleep_wake_minutes": None,
+        },
+        input_mock_fitbit_response={
+            "sleep": [
+                {
+                    "endTime": "2023-05-13T09:27:30.000",
+                    "duration": 31620000,
+                    "startTime": "2023-05-13T00:40:00.000",
+                    "type": "stages",
+                    "isMainSleep": True,
+                    "levels": {
+                        "summary": {"wake": {"minutes": 32}},
+                    },
+                },
+            ]
+        },
+        expected_new_last_sleep_data=SleepData(
+            start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
+            end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
+            sleep_minutes=495,
+            wake_minutes=32,
+        ),
+        expected_icons="",
+    ),
+    "New sleep data higher": FitbitTestScenario(
+        # Previous sleep data exists.
+        # Newer values are all higher than previous values
+        input_initial_sleep_data={
+            "last_sleep_start_time": datetime.datetime(2023, 5, 11, 23, 39, 0),
+            "last_sleep_end_time": datetime.datetime(2023, 5, 12, 8, 28, 0),
+            "last_sleep_sleep_minutes": 449,
+            "last_sleep_wake_minutes": 80,
+        },
+        input_mock_fitbit_response={
+            "sleep": [
+                {
+                    "startTime": "2023-05-13T00:40:00.000",
+                    "endTime": "2023-05-13T09:27:30.000",
+                    "duration": 31620000,
+                    "type": "classic",
+                    "isMainSleep": True,
+                    "levels": {
+                        "summary": {
+                            "asleep": {"minutes": 495},
+                            "awake": {"minutes": 130},
+                        },
+                    },
+                },
+            ]
+        },
+        expected_new_last_sleep_data=SleepData(
+            start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
+            end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
+            sleep_minutes=495,
+            wake_minutes=130,
+        ),
+        expected_icons="⬆️.*⬆️.*⬆️.*⬆️",
+    ),
+    "New sleep data slightly higher": FitbitTestScenario(
+        # Previous sleep data exists.
+        # Newer values are all slightly higher than previous values
+        input_initial_sleep_data={
+            "last_sleep_start_time": datetime.datetime(2023, 5, 12, 0, 5, 0),
+            "last_sleep_end_time": datetime.datetime(2023, 5, 12, 9, 0, 0),
+            "last_sleep_sleep_minutes": 460,
+            "last_sleep_wake_minutes": 16,
+        },
+        input_mock_fitbit_response={
+            "sleep": [
+                {
+                    "startTime": "2023-05-13T00:40:00.000",
+                    "endTime": "2023-05-13T09:27:30.000",
+                    "duration": 32700000,
+                    "type": "stages",
+                    "isMainSleep": True,
+                    "levels": {
+                        "summary": {"wake": {"minutes": 50}},
+                    },
+                },
+            ]
+        },
+        expected_new_last_sleep_data=SleepData(
+            start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
+            end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
+            sleep_minutes=495,
+            wake_minutes=50,
+        ),
+        expected_icons="↗️.*↗️.*↗️.*↗️",
+    ),
+    "New sleep data barely higher": FitbitTestScenario(
+        # Previous sleep data exists.
+        # Newer values are all barely higher than previous values
+        input_initial_sleep_data={
+            "last_sleep_start_time": datetime.datetime(2023, 5, 12, 0, 39, 0),
+            "last_sleep_end_time": datetime.datetime(2023, 5, 12, 9, 25, 0),
+            "last_sleep_sleep_minutes": 490,
+            "last_sleep_wake_minutes": 45,
+        },
+        input_mock_fitbit_response={
+            "sleep": [
+                {
+                    "startTime": "2023-05-13T00:40:00.000",
+                    "endTime": "2023-05-13T09:27:30.000",
+                    "duration": 31620000,
+                    "type": "classic",
+                    "isMainSleep": True,
+                    "levels": {
+                        "summary": {
+                            "asleep": {"minutes": 495},
+                            "awake": {"minutes": 50},
+                        },
+                    },
+                },
+            ]
+        },
+        expected_new_last_sleep_data=SleepData(
+            start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
+            end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
+            sleep_minutes=495,
+            wake_minutes=50,
+        ),
+        expected_icons="➡️.*➡️.*➡️.*➡️",
+    ),
+    "New sleep data barely lower": FitbitTestScenario(
+        # Previous sleep data exists.
+        # Newer values are all barely lower than previous values
+        input_initial_sleep_data={
+            "last_sleep_start_time": datetime.datetime(2023, 5, 12, 0, 41, 0),
+            "last_sleep_end_time": datetime.datetime(2023, 5, 12, 9, 28, 0),
+            "last_sleep_sleep_minutes": 500,
+            "last_sleep_wake_minutes": 51,
+        },
+        input_mock_fitbit_response={
+            "sleep": [
+                {
+                    "startTime": "2023-05-13T00:40:00.000",
+                    "endTime": "2023-05-13T09:27:30.000",
+                    "duration": 31620000,
+                    "type": "classic",
+                    "isMainSleep": True,
+                    "levels": {
+                        "summary": {
+                            "asleep": {"minutes": 495},
+                            "awake": {"minutes": 50},
+                        },
+                    },
+                },
+            ]
+        },
+        expected_new_last_sleep_data=SleepData(
+            start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
+            end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
+            sleep_minutes=495,
+            wake_minutes=50,
+        ),
+        expected_icons="➡️.*➡️.*➡️.*➡️",
+    ),
+    "New sleep data slightly lower": FitbitTestScenario(
+        # Previous sleep data exists.
+        # Newer values are all slightly lower than previous values
+        input_initial_sleep_data={
+            "last_sleep_start_time": datetime.datetime(2023, 5, 12, 1, 15, 0),
+            "last_sleep_end_time": datetime.datetime(2023, 5, 12, 10, 11, 0),
+            "last_sleep_sleep_minutes": 539,
+            "last_sleep_wake_minutes": 80,
+        },
+        input_mock_fitbit_response={
+            "sleep": [
+                {
+                    "startTime": "2023-05-13T00:40:00.000",
+                    "endTime": "2023-05-13T09:27:30.000",
+                    "duration": 31620000,
+                    "type": "classic",
+                    "isMainSleep": True,
+                    "levels": {
+                        "summary": {
+                            "asleep": {"minutes": 495},
+                            "awake": {"minutes": 50},
+                        },
+                    },
+                },
+            ]
+        },
+        expected_new_last_sleep_data=SleepData(
+            start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
+            end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
+            sleep_minutes=495,
+            wake_minutes=50,
+        ),
+        expected_icons="↘️.*↘️.*↘️.*↘️",
+    ),
+    "New sleep data lower": FitbitTestScenario(
+        # Previous sleep data exists.
+        # Newer values are all lower than previous values
+        input_initial_sleep_data={
+            "last_sleep_start_time": datetime.datetime(2023, 5, 12, 1, 41, 0),
+            "last_sleep_end_time": datetime.datetime(2023, 5, 12, 10, 28, 0),
+            "last_sleep_sleep_minutes": 560,
+            "last_sleep_wake_minutes": 200,
+        },
+        input_mock_fitbit_response={
+            "sleep": [
+                {
+                    "startTime": "2023-05-13T00:40:00.000",
+                    "endTime": "2023-05-13T09:27:30.000",
+                    "duration": 31620000,
+                    "type": "classic",
+                    "isMainSleep": True,
+                    "levels": {
+                        "summary": {
+                            "asleep": {"minutes": 495},
+                            "awake": {"minutes": 130},
+                        },
+                    },
+                },
+            ]
+        },
+        expected_new_last_sleep_data=SleepData(
+            start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
+            end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
+            sleep_minutes=495,
+            wake_minutes=130,
+        ),
+        expected_icons="⬇️.*⬇️.*⬇️.*⬇️",
+    ),
+}

--- a/tests/routes/test_fitbit_routes.py
+++ b/tests/routes/test_fitbit_routes.py
@@ -1,0 +1,92 @@
+import datetime
+import json
+import re
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from httpx import Response
+from respx import MockRouter
+
+from slackhealthbot.database import crud
+from slackhealthbot.database.models import FitbitUser, User
+from slackhealthbot.services.models import user_last_sleep_data
+from slackhealthbot.settings import settings
+from tests.factories.factories import FitbitUserFactory, UserFactory
+from tests.fixtures.fitbit_scenarios import FitbitTestScenario, scenarios
+
+
+@pytest.mark.parametrize(
+    ids=scenarios.keys(),
+    argnames="scenario",
+    argvalues=scenarios.values(),
+)
+@pytest.mark.asyncio
+async def test_sleep_notification(
+    mocked_async_session,
+    client: TestClient,
+    respx_mock: MockRouter,
+    user_factory: UserFactory,
+    fitbit_user_factory: FitbitUserFactory,
+    scenario: FitbitTestScenario,
+):
+    """
+    Given a user with a given previous sleep logged
+    When we receive the callback from fitbit that a new sleep is available
+    Then the last sleep is updated in the database
+    And the message is posted to slack with the correct icons.
+    """
+
+    # Given a user with the given previous sleep data
+    user: User = user_factory(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory(
+        user_id=user.id,
+        **scenario.input_initial_sleep_data,
+        oauth_expiration_date=datetime.datetime.utcnow() + datetime.timedelta(days=1),
+    )
+
+    db_user = await crud.get_user(
+        mocked_async_session, fitbit_oauth_userid=fitbit_user.oauth_userid
+    )
+    db_fitbit_user = db_user.fitbit
+    # The user has the previous sleep logged
+    assert (
+        db_fitbit_user.last_sleep_sleep_minutes
+        == scenario.input_initial_sleep_data["last_sleep_sleep_minutes"]
+    )
+
+    # Mock fitbit endpoint to return some sleep data
+    respx_mock.get(
+        url=f"{settings.fitbit_base_url}1.2/user/-/sleep/date/2023-05-12.json",
+    ).mock(Response(status_code=200, json=scenario.input_mock_fitbit_response))
+
+    # Mock an empty ok response from the slack webhook
+    slack_request = respx_mock.post(f"{settings.slack_webhook_url}").mock(
+        return_value=Response(200)
+    )
+
+    # When we receive the callback from fitbit that a new weight is available
+    response = client.post(
+        "/fitbit-notification-webhook/",
+        content=json.dumps(
+            [
+                {
+                    "ownerId": user.fitbit.oauth_userid,
+                    "date": 1683894606,
+                    "collectionType": "sleep",
+                }
+            ]
+        ),
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # Then the last sleep data is updated in the database
+    actual_last_sleep_data = user_last_sleep_data(db_user.fitbit)
+    assert actual_last_sleep_data == scenario.expected_new_last_sleep_data
+
+    # And the message was sent to slack as expected
+    actual_message = json.loads(slack_request.calls[0].request.content)["text"].replace(
+        "\n", ""
+    )
+    assert re.search(scenario.expected_icons, actual_message)

--- a/tests/routes/test_withings_routes.py
+++ b/tests/routes/test_withings_routes.py
@@ -29,7 +29,7 @@ from tests.factories.factories import UserFactory, WithingsUserFactory
     ],
 )
 @pytest.mark.asyncio
-async def test_first_user_weight(
+async def test_weight_notification(
     mocked_async_session,
     client: TestClient,
     respx_mock: MockRouter,
@@ -58,7 +58,7 @@ async def test_first_user_weight(
         mocked_async_session, withings_oauth_userid=withings_user.oauth_userid
     )
     db_withings_user = db_user.withings
-    # The user has no previous weight logged
+    # The user has the previous weight logged
     assert db_withings_user.last_weight == input_initial_weight
 
     # Mock withings endpoint to return some weight data

--- a/tests/test_fitbit_poll.py
+++ b/tests/test_fitbit_poll.py
@@ -8,253 +8,16 @@ from respx import MockRouter
 
 from slackhealthbot.database.models import User
 from slackhealthbot.scheduler import Cache, do_poll
-from slackhealthbot.services.models import SleepData, user_last_sleep_data
+from slackhealthbot.services.models import user_last_sleep_data
 from slackhealthbot.settings import settings
 from tests.factories.factories import FitbitUserFactory, UserFactory
+from tests.fixtures.fitbit_scenarios import FitbitTestScenario, scenarios
 
 
 @pytest.mark.parametrize(
-    ids=[
-        "No previous sleep data",
-        "New sleep data higher",
-        "New sleep data slightly higher",
-        "New sleep data barely higher",
-        "New sleep data barely lower",
-        "New sleep data slightly lower",
-        "New sleep data lower",
-    ],
-    argnames="input_initial_sleep_data, "
-    "input_mock_fitbit_response, "
-    "expected_new_last_sleep_data, "
-    "expected_icons",
-    argvalues=[
-        (
-            # No previous sleep data
-            {},
-            {
-                "sleep": [
-                    {
-                        "endTime": "2023-05-13T09:27:30.000",
-                        "duration": 31620000,
-                        "startTime": "2023-05-13T00:40:00.000",
-                        "type": "stages",
-                        "isMainSleep": True,
-                        "levels": {
-                            "summary": {"wake": {"minutes": 32}},
-                        },
-                    },
-                ]
-            },
-            SleepData(
-                start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
-                end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
-                sleep_minutes=495,
-                wake_minutes=32,
-            ),
-            "",
-        ),
-        (
-            # Previous sleep data exists.
-            # Newer values are all higher than previous values
-            {
-                "last_sleep_start_time": datetime.datetime(2023, 5, 11, 23, 39, 0),
-                "last_sleep_end_time": datetime.datetime(2023, 5, 12, 8, 28, 0),
-                "last_sleep_sleep_minutes": 449,
-                "last_sleep_wake_minutes": 80,
-            },
-            {
-                "sleep": [
-                    {
-                        "startTime": "2023-05-13T00:40:00.000",
-                        "endTime": "2023-05-13T09:27:30.000",
-                        "duration": 31620000,
-                        "type": "classic",
-                        "isMainSleep": True,
-                        "levels": {
-                            "summary": {
-                                "asleep": {"minutes": 495},
-                                "awake": {"minutes": 130},
-                            },
-                        },
-                    },
-                ]
-            },
-            SleepData(
-                start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
-                end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
-                sleep_minutes=495,
-                wake_minutes=130,
-            ),
-            "⬆️.*⬆️.*⬆️.*⬆️",
-        ),
-        (
-            # Previous sleep data exists.
-            # Newer values are all slightly higher than previous values
-            {
-                "last_sleep_start_time": datetime.datetime(2023, 5, 12, 0, 5, 0),
-                "last_sleep_end_time": datetime.datetime(2023, 5, 12, 9, 0, 0),
-                "last_sleep_sleep_minutes": 460,
-                "last_sleep_wake_minutes": 16,
-            },
-            {
-                "sleep": [
-                    {
-                        "startTime": "2023-05-13T00:40:00.000",
-                        "endTime": "2023-05-13T09:27:30.000",
-                        "duration": 32700000,
-                        "type": "stages",
-                        "isMainSleep": True,
-                        "levels": {
-                            "summary": {"wake": {"minutes": 50}},
-                        },
-                    },
-                ]
-            },
-            SleepData(
-                start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
-                end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
-                sleep_minutes=495,
-                wake_minutes=50,
-            ),
-            "↗️.*↗️.*↗️.*↗️",
-        ),
-        (
-            # Previous sleep data exists.
-            # Newer values are all barely higher than previous values
-            {
-                "last_sleep_start_time": datetime.datetime(2023, 5, 12, 0, 39, 0),
-                "last_sleep_end_time": datetime.datetime(2023, 5, 12, 9, 25, 0),
-                "last_sleep_sleep_minutes": 490,
-                "last_sleep_wake_minutes": 45,
-            },
-            {
-                "sleep": [
-                    {
-                        "startTime": "2023-05-13T00:40:00.000",
-                        "endTime": "2023-05-13T09:27:30.000",
-                        "duration": 31620000,
-                        "type": "classic",
-                        "isMainSleep": True,
-                        "levels": {
-                            "summary": {
-                                "asleep": {"minutes": 495},
-                                "awake": {"minutes": 50},
-                            },
-                        },
-                    },
-                ]
-            },
-            SleepData(
-                start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
-                end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
-                sleep_minutes=495,
-                wake_minutes=50,
-            ),
-            "➡️.*➡️.*➡️.*➡️",
-        ),
-        (
-            # Previous sleep data exists.
-            # Newer values are all barely lower than previous values
-            {
-                "last_sleep_start_time": datetime.datetime(2023, 5, 12, 0, 41, 0),
-                "last_sleep_end_time": datetime.datetime(2023, 5, 12, 9, 28, 0),
-                "last_sleep_sleep_minutes": 500,
-                "last_sleep_wake_minutes": 51,
-            },
-            {
-                "sleep": [
-                    {
-                        "startTime": "2023-05-13T00:40:00.000",
-                        "endTime": "2023-05-13T09:27:30.000",
-                        "duration": 31620000,
-                        "type": "classic",
-                        "isMainSleep": True,
-                        "levels": {
-                            "summary": {
-                                "asleep": {"minutes": 495},
-                                "awake": {"minutes": 50},
-                            },
-                        },
-                    },
-                ]
-            },
-            SleepData(
-                start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
-                end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
-                sleep_minutes=495,
-                wake_minutes=50,
-            ),
-            "➡️.*➡️.*➡️.*➡️",
-        ),
-        (
-            # Previous sleep data exists.
-            # Newer values are all slightly lower than previous values
-            {
-                "last_sleep_start_time": datetime.datetime(2023, 5, 12, 1, 15, 0),
-                "last_sleep_end_time": datetime.datetime(2023, 5, 12, 10, 11, 0),
-                "last_sleep_sleep_minutes": 539,
-                "last_sleep_wake_minutes": 80,
-            },
-            {
-                "sleep": [
-                    {
-                        "startTime": "2023-05-13T00:40:00.000",
-                        "endTime": "2023-05-13T09:27:30.000",
-                        "duration": 31620000,
-                        "type": "classic",
-                        "isMainSleep": True,
-                        "levels": {
-                            "summary": {
-                                "asleep": {"minutes": 495},
-                                "awake": {"minutes": 50},
-                            },
-                        },
-                    },
-                ]
-            },
-            SleepData(
-                start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
-                end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
-                sleep_minutes=495,
-                wake_minutes=50,
-            ),
-            "↘️.*↘️.*↘️.*↘️",
-        ),
-        (
-            # Previous sleep data exists.
-            # Newer values are all lower than previous values
-            {
-                "last_sleep_start_time": datetime.datetime(2023, 5, 12, 1, 41, 0),
-                "last_sleep_end_time": datetime.datetime(2023, 5, 12, 10, 28, 0),
-                "last_sleep_sleep_minutes": 560,
-                "last_sleep_wake_minutes": 200,
-            },
-            {
-                "sleep": [
-                    {
-                        "startTime": "2023-05-13T00:40:00.000",
-                        "endTime": "2023-05-13T09:27:30.000",
-                        "duration": 31620000,
-                        "type": "classic",
-                        "isMainSleep": True,
-                        "levels": {
-                            "summary": {
-                                "asleep": {"minutes": 495},
-                                "awake": {"minutes": 130},
-                            },
-                        },
-                    },
-                ]
-            },
-            SleepData(
-                start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
-                end_time=datetime.datetime(2023, 5, 13, 9, 27, 30),
-                sleep_minutes=495,
-                wake_minutes=130,
-            ),
-            "⬇️.*⬇️.*⬇️.*⬇️",
-        ),
-    ],
+    ids=scenarios.keys(),
+    argnames="scenario",
+    argvalues=scenarios.values(),
 )
 @pytest.mark.asyncio
 async def test_fitbit_poll(
@@ -262,10 +25,7 @@ async def test_fitbit_poll(
     respx_mock: MockRouter,
     user_factory: UserFactory,
     fitbit_user_factory: FitbitUserFactory,
-    input_initial_sleep_data,
-    input_mock_fitbit_response,
-    expected_new_last_sleep_data,
-    expected_icons,
+    scenario: FitbitTestScenario,
 ):
     """
     Given a user with given previous sleep data logged
@@ -278,14 +38,14 @@ async def test_fitbit_poll(
     user: User = user_factory(fitbit=None)
     fitbit_user_factory(
         user_id=user.id,
-        **input_initial_sleep_data,
+        **scenario.input_initial_sleep_data,
         oauth_expiration_date=datetime.datetime.utcnow() + datetime.timedelta(days=1),
     )
 
     # Mock fitbit endpoint to return some sleep data
     respx_mock.get(
         url=f"{settings.fitbit_base_url}1.2/user/-/sleep/date/2023-01-23.json",
-    ).mock(Response(status_code=200, json=input_mock_fitbit_response))
+    ).mock(Response(status_code=200, json=scenario.input_mock_fitbit_response))
 
     # Mock an empty ok response from the slack webhook
     slack_request = respx_mock.post(f"{settings.slack_webhook_url}").mock(
@@ -299,10 +59,10 @@ async def test_fitbit_poll(
 
     # Then the last sleep data is updated in the database
     actual_last_sleep_data = user_last_sleep_data(user.fitbit)
-    assert actual_last_sleep_data == expected_new_last_sleep_data
+    assert actual_last_sleep_data == scenario.expected_new_last_sleep_data
 
     # And the message was sent to slack as expected
     actual_message = json.loads(slack_request.calls[0].request.content)["text"].replace(
         "\n", ""
     )
-    assert re.search(expected_icons, actual_message)
+    assert re.search(scenario.expected_icons, actual_message)


### PR DESCRIPTION
---

Fix naming and comments in test_withings_routes:

The test `test_first_user_weight` initially only tested a scenario where no previous weight was logged. It was modified after to test different scenarios. Updating the test name and inline comments to reflect that.

---

Extract test scenarios out of test_fitbit_poll into fitbit_scenarios.

---

Add a test for the fitbit notification webhook.
    
It currently fails because we don't correctly save the sleep data.

---

Fix bug where sleep data wasn't saved when the fitbit notification webhook was called.