### PR TITLE
Handle invalid responses returned by fitbit for retrieving sleep and activities

### DIFF
--- a/slackhealthbot/services/fitbit/parser.py
+++ b/slackhealthbot/services/fitbit/parser.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from typing import Annotated, Literal, Optional, Self, Union
 
 from pydantic import BaseModel, Field
@@ -88,7 +89,11 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
 
 def parse_sleep(input: str, slack_alias: str) -> Optional[svc_models.SleepData]:
-    fitbit_sleep = FitbitSleep.parse(input)
+    try:
+        fitbit_sleep = FitbitSleep.parse(input)
+    except Exception as e:
+        logging.warning(f"Error parsing sleep: error {e}, input: {input}", exc_info=e)
+        return None
     main_sleep_item = next(
         (item for item in fitbit_sleep.sleep if item.isMainSleep), None
     )
@@ -117,7 +122,13 @@ def parse_sleep(input: str, slack_alias: str) -> Optional[svc_models.SleepData]:
 
 
 def parse_activity(input: str) -> Optional[svc_models.ActivityData]:
-    fitbit_activities = FitbitActivities.parse(input)
+    try:
+        fitbit_activities = FitbitActivities.parse(input)
+    except Exception as e:
+        logging.warning(
+            f"Error parsing activity: error {e}, input: {input}", exc_info=e
+        )
+        return None
     if not fitbit_activities.activities:
         return None
     fitbit_activity = fitbit_activities.activities[0]

--- a/tests/fixtures/fitbit_scenarios.py
+++ b/tests/fixtures/fitbit_scenarios.py
@@ -10,7 +10,7 @@ class FitbitSleepScenario:
     input_initial_sleep_data: dict[str, int]
     input_mock_fitbit_response: dict[str, Any]
     expected_new_last_sleep_data: SleepData
-    expected_icons: str
+    expected_icons: str | None
 
 
 sleep_scenarios: dict[str, FitbitSleepScenario] = {
@@ -245,6 +245,22 @@ sleep_scenarios: dict[str, FitbitSleepScenario] = {
         ),
         expected_icons="⬇️.*⬇️.*⬇️.*⬇️",
     ),
+    "Invalid json response": FitbitSleepScenario(
+        input_initial_sleep_data={
+            "last_sleep_start_time": datetime.datetime(2023, 5, 12, 1, 41, 0),
+            "last_sleep_end_time": datetime.datetime(2023, 5, 12, 10, 28, 0),
+            "last_sleep_sleep_minutes": 560,
+            "last_sleep_wake_minutes": 200,
+        },
+        input_mock_fitbit_response={"foo": "bar"},
+        expected_new_last_sleep_data=SleepData(
+            start_time=datetime.datetime(2023, 5, 12, 1, 41, 0),
+            end_time=datetime.datetime(2023, 5, 12, 10, 28, 0),
+            sleep_minutes=560,
+            wake_minutes=200,
+        ),
+        expected_icons=None,
+    ),
 }
 
 
@@ -399,6 +415,12 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
                 },
             ]
         },
+        expected_new_last_activity_log_id=1234,
+        expected_message_pattern=None,
+    ),
+    "Invalid json response": FitbitActivityScenario(
+        input_last_activity_log_id=1234,
+        input_mock_fitbit_response={"foo": "bar"},
         expected_new_last_activity_log_id=1234,
         expected_message_pattern=None,
     ),

--- a/tests/routes/test_fitbit_routes.py
+++ b/tests/routes/test_fitbit_routes.py
@@ -91,10 +91,13 @@ async def test_sleep_notification(
     assert actual_last_sleep_data == scenario.expected_new_last_sleep_data
 
     # And the message was sent to slack as expected
-    actual_message = json.loads(slack_request.calls[0].request.content)["text"].replace(
-        "\n", ""
-    )
-    assert re.search(scenario.expected_icons, actual_message)
+    if scenario.expected_icons is not None:
+        actual_message = json.loads(slack_request.calls[0].request.content)[
+            "text"
+        ].replace("\n", "")
+        assert re.search(scenario.expected_icons, actual_message)
+    else:
+        assert not slack_request.calls
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fitbit_poll.py
+++ b/tests/test_fitbit_poll.py
@@ -72,10 +72,13 @@ async def test_fitbit_poll_sleep(
     assert actual_last_sleep_data == scenario.expected_new_last_sleep_data
 
     # And the message was sent to slack as expected
-    actual_message = json.loads(slack_request.calls[0].request.content)["text"].replace(
-        "\n", ""
-    )
-    assert re.search(scenario.expected_icons, actual_message)
+    if scenario.expected_icons is not None:
+        actual_message = json.loads(slack_request.calls[0].request.content)[
+            "text"
+        ].replace("\n", "")
+        assert re.search(scenario.expected_icons, actual_message)
+    else:
+        assert not slack_request.calls
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add tests for invalid json responses returned by fitbit for retrieving sleep and activities.

Handle errors parsing fitbit responses for sleep and activities.