### PR TITLE
Refactoring preparation to show progress of fitbit activities

### DIFF
--- a/slackhealthbot/services/fitbit/parser.py
+++ b/slackhealthbot/services/fitbit/parser.py
@@ -61,7 +61,7 @@ class FitbitSleep(BaseModel):
 
 class FitbitMinutesInHeartRateZone(BaseModel):
     minutes: int
-    zoneName: str
+    type: str
 
 
 class FitBitActiveZoneMinutes(BaseModel):
@@ -139,7 +139,7 @@ def parse_activity(input: str) -> Optional[svc_models.ActivityData]:
         calories=fitbit_activity.calories,
         total_minutes=fitbit_activity.duration / 60000,
         zone_minutes=[
-            svc_models.ActivityZoneMinutes(name=x.zoneName, minutes=x.minutes)
+            svc_models.ActivityZoneMinutes(zone=x.type.lower(), minutes=x.minutes)
             for x in fitbit_activity.activeZoneMinutes.minutesInHeartRateZones
             if x.minutes > 0
         ],

--- a/slackhealthbot/services/fitbit/service.py
+++ b/slackhealthbot/services/fitbit/service.py
@@ -40,7 +40,7 @@ async def save_new_activity_data(
     )
 
 
-def _is_new_valid_activity(user: User, activity: ActivityData | None):
+def _is_new_valid_activity(user: User, activity: ActivityData | None) -> bool:
     return (
         activity
         and activity.log_id != user.fitbit.last_activity_log_id

--- a/slackhealthbot/services/models.py
+++ b/slackhealthbot/services/models.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+from enum import StrEnum, auto
 from typing import Optional
 
 from pydantic import BaseModel, NonNegativeInt
@@ -21,8 +22,15 @@ class SleepData(BaseModel):
     wake_minutes: NonNegativeInt
 
 
+class ActivityZone(StrEnum):
+    PEAK = auto()
+    CARDIO = auto()
+    FAT_BURN = auto()
+    OUT_OF_RANGE = auto()
+
+
 class ActivityZoneMinutes(BaseModel):
-    name: str
+    zone: ActivityZone
     minutes: int
 
 

--- a/slackhealthbot/services/slack.py
+++ b/slackhealthbot/services/slack.py
@@ -2,7 +2,12 @@ import datetime
 
 import httpx
 
-from slackhealthbot.services.models import ActivityData, SleepData, WeightData
+from slackhealthbot.services.models import (
+    ActivityData,
+    ActivityZone,
+    SleepData,
+    WeightData,
+)
 from slackhealthbot.settings import settings
 
 
@@ -43,6 +48,10 @@ def format_minutes(total_minutes: int) -> str:
 
 def format_time(input: datetime.datetime) -> str:
     return input.strftime("%-H:%M")
+
+
+def format_activity_zone(activity_zone: ActivityZone) -> str:
+    return activity_zone.name.capitalize().replace("_", " ")
 
 
 def get_seconds_change_icon(seconds_change: int) -> str:
@@ -118,7 +127,8 @@ New {activity_data.name} activity from <@{slack_alias}>:
 """
     message += "\n".join(
         [
-            f"    • {zone_minutes.name} minutes: {zone_minutes.minutes}."
+            f"    • {format_activity_zone(zone_minutes.zone)}"
+            + f" minutes: {zone_minutes.minutes}."
             for zone_minutes in activity_data.zone_minutes
         ]
     )

--- a/tests/fixtures/fitbit_scenarios.py
+++ b/tests/fixtures/fitbit_scenarios.py
@@ -282,19 +282,19 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
                         "minutesInHeartRateZones": [
                             {
                                 "minutes": 8,
-                                "zoneName": "Fat Burn",
+                                "type": "FAT_BURN",
                             },
                             {
                                 "minutes": 0,
-                                "zoneName": "Cardio",
+                                "type": "CARDIO",
                             },
                             {
                                 "minutes": 0,
-                                "zoneName": "Out of Range",
+                                "type": "OUT_OF_RANGE",
                             },
                             {
                                 "minutes": 0,
-                                "zoneName": "Peak",
+                                "type": "PEAK",
                             },
                         ]
                     },
@@ -307,7 +307,7 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
             ]
         },
         expected_new_last_activity_log_id=1234,
-        expected_message_pattern="New Spinning activity.*Fat Burn.*8",
+        expected_message_pattern="New Spinning activity.*Fat burn.*8",
     ),
     "New Spinning activity, partial zones": FitbitActivityScenario(
         input_last_activity_log_id=1234,
@@ -318,19 +318,19 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
                         "minutesInHeartRateZones": [
                             {
                                 "minutes": 8,
-                                "zoneName": "Fat Burn",
+                                "type": "FAT_BURN",
                             },
                             {
                                 "minutes": 9,
-                                "zoneName": "Cardio",
+                                "type": "CARDIO",
                             },
                             {
                                 "minutes": 0,
-                                "zoneName": "Out of Range",
+                                "type": "OUT_OF_RANGE",
                             },
                             {
                                 "minutes": 0,
-                                "zoneName": "Peak",
+                                "type": "PEAK",
                             },
                         ]
                     },
@@ -343,7 +343,7 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
             ]
         },
         expected_new_last_activity_log_id=1235,
-        expected_message_pattern="New Spinning activity.*Fat Burn.*8.*Cardio.*9",
+        expected_message_pattern="New Spinning activity.*Fat burn.*8.*Cardio.*9",
     ),
     "New Spinning activity, full zones": FitbitActivityScenario(
         input_last_activity_log_id=1234,
@@ -354,19 +354,19 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
                         "minutesInHeartRateZones": [
                             {
                                 "minutes": 8,
-                                "zoneName": "Fat Burn",
+                                "type": "FAT_BURN",
                             },
                             {
                                 "minutes": 9,
-                                "zoneName": "Cardio",
+                                "type": "CARDIO",
                             },
                             {
                                 "minutes": 10,
-                                "zoneName": "Out of Range",
+                                "type": "OUT_OF_RANGE",
                             },
                             {
                                 "minutes": 11,
-                                "zoneName": "Peak",
+                                "type": "PEAK",
                             },
                         ]
                     },
@@ -380,7 +380,7 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
         },
         expected_new_last_activity_log_id=1235,
         expected_message_pattern="New Spinning activity.*"
-        + "Fat Burn.*8.*Cardio.*9.*Out of Range.*10.*Peak.*11",
+        + "Fat burn.*8.*Cardio.*9.*Out of range.*10.*Peak.*11",
     ),
     "New unrecognized activity": FitbitActivityScenario(
         input_last_activity_log_id=1234,
@@ -391,19 +391,19 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
                         "minutesInHeartRateZones": [
                             {
                                 "minutes": 8,
-                                "zoneName": "Fat Burn",
+                                "type": "FAT_BURN",
                             },
                             {
                                 "minutes": 9,
-                                "zoneName": "Cardio",
+                                "type": "CARDIO",
                             },
                             {
                                 "minutes": 0,
-                                "zoneName": "Out of Range",
+                                "type": "OUT_OF_RANGE",
                             },
                             {
                                 "minutes": 0,
-                                "zoneName": "Peak",
+                                "type": "PEAK",
                             },
                         ]
                     },


### PR DESCRIPTION
* Define an enum for the activity zone, instead of using the zoneName from the fitbit api directly.
    This will help us to refer to specific column names of the future activities table, like `cardio_minutes` or `fat_burn_minutes`.
* Remove some assertions from unit tests that are redundant with factory tests.