### PR TITLE
Fix issue where slack message for an activity may contain "None".

### DIFF
--- a/slackhealthbot/services/slack.py
+++ b/slackhealthbot/services/slack.py
@@ -177,7 +177,8 @@ New {activity.name} activity from <@{slack_alias}>:
     message += "\n".join(
         [
             f"    • {format_activity_zone(zone_minutes.zone)}"
-            + f" minutes: {zone_minutes.minutes} {zone_icons.get(zone_minutes.zone)}"
+            + f" minutes: {zone_minutes.minutes} "
+            + zone_icons.get(zone_minutes.zone, "")
             for zone_minutes in activity.zone_minutes
         ]
     )

--- a/tests/routes/test_fitbit_routes.py
+++ b/tests/routes/test_fitbit_routes.py
@@ -184,5 +184,6 @@ async def test_activity_notification(
             "text"
         ].replace("\n", "")
         assert re.search(scenario.expected_message_pattern, actual_message)
+        assert "None" not in actual_message
     else:
         assert not slack_request.calls


### PR DESCRIPTION
Add unit test to reproduce bug where slack message contains "None".

Adapt the slack service to avoid this bug: use an empty string if we can't find the icon.