### PR TITLE
Test oauth token refresh and fix related bugs

### DIFF
--- a/slackhealthbot/services/fitbit/service.py
+++ b/slackhealthbot/services/fitbit/service.py
@@ -95,9 +95,9 @@ async def get_activity(
     user: User,
     when: datetime.datetime,
 ) -> ActivityHistory | None:
+    activity = await api.get_activity(db, user, when)
     # lazy load activity data
     await user.fitbit.awaitable_attrs.latest_activities
-    activity = await api.get_activity(db, user, when)
     if not _is_new_valid_activity(user, activity):
         return None
     latest_activity = await get_latest_activity(

--- a/slackhealthbot/services/withings/requests.py
+++ b/slackhealthbot/services/withings/requests.py
@@ -26,5 +26,5 @@ async def post(
     response_body = response.json()
     if response_body["status"] == 401 and retry_count > 0:
         await oauth.refresh_token(db, user)
-        return post(db, user, url, data, retry_count - 1)
+        return await post(db, user, url, data, retry_count - 1)
     return response

--- a/tests/routes/test_withings_routes.py
+++ b/tests/routes/test_withings_routes.py
@@ -108,3 +108,125 @@ async def test_weight_notification(
     # And the message is sent to slack as expected
     actual_message = json.loads(slack_request.calls[0].request.content)["text"]
     assert expected_icon in actual_message
+
+
+@pytest.mark.asyncio
+async def test_retry_authentication(
+    mocked_async_session,
+    client: TestClient,
+    respx_mock: MockRouter,
+    user_factory: UserFactory,
+    withings_user_factory: WithingsUserFactory,
+):
+    """
+    Given a user whose access token is no longer valid
+    When we receive the callback from withings that a new weight is available
+    Then the access token is refreshed
+    And the latest weight is updated in the database
+    And the message is posted to slack with the correct pattern.
+    """
+    # Given a user
+    user: User = user_factory(withings=None)
+    withings_user: WithingsUser = withings_user_factory(
+        user_id=user.id,
+        last_weight=50.2,
+        oauth_expiration_date=datetime.datetime.utcnow() + datetime.timedelta(days=1),
+    )
+
+    # Given the user's access token is no longer valid:
+    withings_weight_request = respx_mock.post(
+        url=f"{settings.withings_base_url}measure",
+    ).mock(
+        side_effect=[
+            # Mock withings endpoint to return an unauthorized error
+            Response(
+                status_code=200,
+                json={
+                    "status": 401,
+                },
+            ),
+            # Mock withings endpoint to return some weight data
+            Response(
+                status_code=200,
+                json={
+                    "status": 0,
+                    "body": {
+                        "measuregrps": [
+                            {
+                                "measures": [
+                                    {
+                                        "value": 50050,
+                                        "unit": -3,
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                },
+            ),
+        ]
+    )
+
+    # Mock withings oauth refresh token success
+    respx_mock.post(
+        url=f"{settings.withings_base_url}v2/signature/",
+    ).mock(
+        Response(
+            status_code=200,
+            json={
+                "status": 0,
+                "body": {
+                    "nonce": "some nonce",
+                },
+            },
+        )
+    )
+    oauth_token_refresh_request = respx_mock.post(
+        url=f"{settings.withings_base_url}v2/oauth2",
+    ).mock(
+        Response(
+            status_code=200,
+            json={
+                "status": 0,
+                "body": {
+                    "userid": user.withings.oauth_userid,
+                    "access_token": "some new access token",
+                    "refresh_token": "some new refresh token",
+                    "expires_in": 600,
+                },
+            },
+        )
+    )
+
+    # Mock an empty ok response from the slack webhook
+    slack_request = respx_mock.post(url=f"{settings.slack_webhook_url}").mock(
+        return_value=Response(status_code=200)
+    )
+
+    # When we receive the callback from withings that a new weight is available
+    response = client.post(
+        "/withings-notification-webhook/",
+        data={
+            "userid": withings_user.oauth_userid,
+            "startdate": 1683894606,
+            "enddate": 1686570821,
+        },
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    db_user = await crud.get_user(
+        db=mocked_async_session, withings_oauth_userid=withings_user.oauth_userid
+    )
+    # Then the access token is refreshed.
+    assert withings_weight_request.call_count == 2
+    assert oauth_token_refresh_request.call_count == 1
+    assert db_user.withings.oauth_access_token == "some new access token"
+    assert db_user.withings.oauth_refresh_token == "some new refresh token"
+
+    # And the last_weight is updated in the database
+    assert math.isclose(db_user.withings.last_weight, 50.05)
+
+    # And the message is sent to slack as expected
+    actual_message = json.loads(slack_request.calls[0].request.content)["text"]
+    assert "↘️" in actual_message


### PR DESCRIPTION
* Create unit tests to test refreshing the oauth token after receiving a fitbit or withings notification webhook.
* Fix bugs found by the new tests.
