### PR TITLE
Fitbit: Integrate authlib instead of doing oauth manually

### DIFF
--- a/slackhealthbot/scheduler.py
+++ b/slackhealthbot/scheduler.py
@@ -114,7 +114,6 @@ async def fitbit_poll_sleep(
     if not latest_successful_poll or latest_successful_poll < when:
         try:
             sleep_data = await fitbit_api.get_sleep(
-                db,
                 user=fitbit_user.user,
                 when=when,
             )

--- a/slackhealthbot/services/fitbit/api.py
+++ b/slackhealthbot/services/fitbit/api.py
@@ -2,18 +2,15 @@ import datetime
 import logging
 from typing import Optional
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from slackhealthbot.database import models as db_models
 from slackhealthbot.services import models as svc_models
 from slackhealthbot.services.fitbit import parser, requests
 from slackhealthbot.settings import settings
 
 
-async def subscribe(db: AsyncSession, user: db_models.User):
+async def subscribe(user: db_models.User):
     for collectionPath in ["sleep", "activities"]:
         response = await requests.post(
-            db,
             user=user,
             url=f"{settings.fitbit_base_url}1/user/-/{collectionPath}/apiSubscriptions/{user.fitbit.oauth_userid}-{collectionPath}.json",
         )
@@ -23,7 +20,6 @@ async def subscribe(db: AsyncSession, user: db_models.User):
 
 
 async def get_sleep(
-    db: AsyncSession,
     user: db_models.User,
     when: datetime.date,
 ) -> Optional[svc_models.SleepData]:
@@ -34,7 +30,6 @@ async def get_sleep(
     logging.info(f"get_sleep for user {user.fitbit.oauth_userid}")
     when_str = when.strftime("%Y-%m-%d")
     response = await requests.get(
-        db,
         user=user,
         url=f"{settings.fitbit_base_url}1.2/user/-/sleep/date/{when_str}.json",
     )
@@ -42,7 +37,7 @@ async def get_sleep(
 
 
 async def get_activity(
-    db: AsyncSession, user: db_models.User, when: datetime.datetime
+    user: db_models.User, when: datetime.datetime
 ) -> Optional[svc_models.ActivityData]:
     """
     :raises:
@@ -51,7 +46,6 @@ async def get_activity(
     logging.info(f"get_activity for user {user.fitbit.oauth_userid}")
     when_str = when.strftime("%Y-%m-%dT%H:%M:%S")
     response = await requests.get(
-        db,
         user=user,
         url=f"{settings.fitbit_base_url}1/user/-/activities/list.json",
         params={

--- a/slackhealthbot/services/fitbit/oauth.py
+++ b/slackhealthbot/services/fitbit/oauth.py
@@ -1,41 +1,64 @@
 import dataclasses
 import datetime
-import hashlib
 import logging
-import random
-import string
-from base64 import urlsafe_b64encode
-from typing import Optional, Self
-from urllib.parse import urlencode
+from typing import Self
 
-import httpx
+from authlib.integrations.httpx_client.oauth2_client import AsyncOAuth2Client
+from authlib.integrations.starlette_client import OAuth
+from authlib.integrations.starlette_client.apps import StarletteOAuth2App
+from fastapi import Request
 from pydantic import HttpUrl
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.config import Config
 
 from slackhealthbot.database import crud
 from slackhealthbot.database import models as db_models
+from slackhealthbot.database.connection import ctx_db
 from slackhealthbot.services.exceptions import UserLoggedOutException
 from slackhealthbot.settings import settings
 
 
-@dataclasses.dataclass
-class State:
-    code_verifier: str
-    slack_alias: str
-
-    @property
-    def code_challenge(self) -> Optional[str]:
-        m = hashlib.sha256()
-        m.update(self.code_verifier.encode("utf-8"))
-        return urlsafe_b64encode(m.digest()).decode("utf-8").strip("=")
+async def update_token(token: dict, refresh_token=None, access_token=None):
+    oauth_fields = OauthFields.parse_response_data(token)
+    db = ctx_db.get()
+    await crud.upsert_user(
+        db,
+        fitbit_oauth_userid=oauth_fields.oauth_userid,
+        fitbit_data=dataclasses.asdict(oauth_fields),
+    )
 
 
-@dataclasses.dataclass
-class MemorySettings:
-    oauth_states: dict[str, State] = dataclasses.field(default_factory=dict)
+def fitbit_compliance_fix(session: AsyncOAuth2Client):
+    def _fix_access_token_response(resp):
+        data = resp.json()
+        logging.info(f"Token response {data}")
+        if resp.status_code != 200:
+            raise UserLoggedOutException
+        data["userid"] = data["user_id"]
+        resp.json = lambda: data
+        return resp
+
+    session.register_compliance_hook(
+        "refresh_token_response", _fix_access_token_response
+    )
+    session.register_compliance_hook(
+        "access_token_response", _fix_access_token_response
+    )
 
 
-_settings = MemorySettings()
+config = Config(".env")
+oauth = OAuth(config)
+oauth.register(
+    name="fitbit",
+    api_base_url=settings.fitbit_base_url,
+    authorize_url="https://www.fitbit.com/oauth2/authorize",
+    access_token_url=f"{settings.fitbit_base_url}oauth2/token",
+    authorize_params={"scope": " ".join(settings.fitbit_oauth_scopes)},
+    compliance_fix=fitbit_compliance_fix,
+    update_token=update_token,
+    token_endpoint_auth_method="client_secret_basic",
+    client_kwargs={"code_challenge_method": "S256"},
+)
 
 
 @dataclasses.dataclass
@@ -52,102 +75,27 @@ class OauthFields:
             oauth_access_token=response_data["access_token"],
             oauth_refresh_token=response_data["refresh_token"],
             oauth_expiration_date=datetime.datetime.utcnow()
-            + datetime.timedelta(seconds=response_data["expires_in"]),
+            + datetime.timedelta(seconds=response_data["expires_in"])
+            - datetime.timedelta(minutes=5),
         )
 
 
-def _authorization_headers():
-    authorization = urlsafe_b64encode(
-        f"{settings.fitbit_client_id}:{settings.fitbit_client_secret}".encode("utf-8")
-    ).decode("utf-8")
-    return {
-        "Authorization": f"Basic {authorization}",
-    }
-
-
-def create_oauth_url(slack_alias: str) -> HttpUrl:
-    url = "https://www.fitbit.com/oauth2/authorize"
-    state_key = "".join(random.choices(string.ascii_lowercase, k=16))
-    state_value = State(
-        code_verifier="".join(random.choices(string.ascii_lowercase, k=100)),
-        slack_alias=slack_alias,
+async def create_oauth_url(request: Request, slack_alias: str) -> HttpUrl:
+    request.session["slack_alias"] = slack_alias
+    fitbit: StarletteOAuth2App = oauth.create_client("fitbit")
+    return await fitbit.authorize_redirect(
+        request,
     )
-    _settings.oauth_states[state_key] = state_value
-
-    query_params = {
-        "client_id": settings.fitbit_client_id,
-        "response_type": "code",
-        "code_challenge": state_value.code_challenge,
-        "code_challenge_method": "S256",
-        "scope": " ".join(settings.fitbit_oauth_scopes),
-        "state": state_key,
-    }
-    return f"{url}?{urlencode(query_params)}"
 
 
-async def fetch_token(db: AsyncSession, code: str, state: str) -> db_models.User:
-    state_value = _settings.oauth_states.pop(state, None)
-    if not state_value:
-        raise ValueError("Invalid state parameter")
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            f"{settings.fitbit_base_url}oauth2/token",
-            headers=_authorization_headers(),
-            data={
-                "client_id": settings.fitbit_client_id,
-                "grant_type": "authorization_code",
-                "code": code,
-                "code_verifier": state_value.code_verifier,
-            },
-        )
-    response_data = response.json()
-    oauth_userid = response_data["user_id"]
-    oauth_fields = OauthFields.parse_response_data(response_data)
+async def fetch_token(db: AsyncSession, request: Request) -> db_models.User:
+    fitbit: StarletteOAuth2App = oauth.create_client("fitbit")
+    response = await fitbit.authorize_access_token(request)
+    oauth_fields = OauthFields.parse_response_data(response)
     user = await crud.upsert_user(
         db,
-        fitbit_oauth_userid=oauth_userid,
-        data={"slack_alias": state_value.slack_alias},
+        fitbit_oauth_userid=response["userid"],
+        data={"slack_alias": request.session.pop("slack_alias")},
         fitbit_data=dataclasses.asdict(oauth_fields),
     )
     return user
-
-
-async def get_access_token(db: AsyncSession, user: db_models.User) -> str:
-    """
-    :raises:
-        UserLoggedOutException if the refresh token request fails
-    """
-    if (
-        not user.fitbit.oauth_expiration_date
-        or user.fitbit.oauth_expiration_date < datetime.datetime.utcnow()
-    ):
-        await refresh_token(db, user)
-    return user.fitbit.oauth_access_token
-
-
-async def refresh_token(db: AsyncSession, user: db_models.User) -> str:
-    """
-    :raises:
-        UserLoggedOutException if the refresh token request fails
-    """
-    logging.info(f"Refreshing fitbit access token for {user.slack_alias}")
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            f"{settings.fitbit_base_url}oauth2/token",
-            headers=_authorization_headers(),
-            data={
-                "client_id": settings.fitbit_client_id,
-                "grant_type": "refresh_token",
-                "refresh_token": user.fitbit.oauth_refresh_token,
-            },
-        )
-    response_data = response.json()
-    if response.status_code != 200:
-        raise UserLoggedOutException
-    oauth_fields = OauthFields.parse_response_data(response_data)
-    user = await crud.update_user(
-        db,
-        user=user,
-        fitbit_data=dataclasses.asdict(oauth_fields),
-    )
-    return user.fitbit.oauth_access_token

--- a/slackhealthbot/services/fitbit/requests.py
+++ b/slackhealthbot/services/fitbit/requests.py
@@ -1,67 +1,44 @@
-import functools
 from typing import Any
 
 import httpx
-from sqlalchemy.ext.asyncio import AsyncSession
+from authlib.integrations.starlette_client.apps import StarletteOAuth2App
 
 from slackhealthbot.database import models as db_models
 from slackhealthbot.services.fitbit import oauth
 
 
-def create_headers(oauth_access_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {oauth_access_token}",
-    }
-
-
-def requires_oauth(func):
-    @functools.wraps(func)
-    async def wrapper(
-        db: AsyncSession,
-        user: db_models.User,
-        url: str,
-        **kwargs,
-    ):
-        oauth_access_token = await oauth.get_access_token(db, user=user)
-        response: httpx.Response = await func(
-            db, user, url, headers=create_headers(oauth_access_token), **kwargs
-        )
-        if response.status_code == 401:
-            new_oauth_access_token = await oauth.refresh_token(db, user)
-            return await func(
-                db, user, url, headers=create_headers(new_oauth_access_token), **kwargs
-            )
-        return response
-
-    return wrapper
-
-
-@requires_oauth
 async def get(
-    _db: AsyncSession,
-    _user: db_models.User,
+    user: db_models.User,
     url: str,
     params: dict[str, Any] = None,
-    headers: dict[str, str] = None,
 ) -> httpx.Response:
     """
     :raises:
         UserLoggedOutException if the refresh token request fails
     """
-    async with httpx.AsyncClient() as client:
-        return await client.get(url, params=params, headers=headers)
+    token = {
+        "access_token": user.fitbit.oauth_access_token,
+        "refresh_token": user.fitbit.oauth_refresh_token,
+        "expires_at": user.fitbit.oauth_expiration_date.timestamp(),
+    }
+    fitbit: StarletteOAuth2App = oauth.oauth.create_client("fitbit")
+    response = await fitbit.get(url, params=params, token=token)
+    return response
 
 
-@requires_oauth
 async def post(
-    _db: AsyncSession,
-    _user: db_models.User,
+    user: db_models.User,
     url: str,
-    headers: dict[str, str] = None,
 ) -> httpx.Response:
     """
     :raises:
         UserLoggedOutException if the refresh token request fails
     """
-    async with httpx.AsyncClient() as client:
-        return await client.post(url, headers=headers)
+    token = {
+        "access_token": user.fitbit.oauth_access_token,
+        "refresh_token": user.fitbit.oauth_refresh_token,
+        "expires_at": user.fitbit.oauth_expiration_date.timestamp(),
+    }
+    fitbit: StarletteOAuth2App = oauth.oauth.create_client("fitbit")
+    response = await fitbit.post(url, token=token)
+    return response

--- a/slackhealthbot/services/fitbit/service.py
+++ b/slackhealthbot/services/fitbit/service.py
@@ -95,7 +95,7 @@ async def get_activity(
     user: User,
     when: datetime.datetime,
 ) -> ActivityHistory | None:
-    activity = await api.get_activity(db, user, when)
+    activity = await api.get_activity(user, when)
     # lazy load activity data
     await user.fitbit.awaitable_attrs.latest_activities
     if not _is_new_valid_activity(user, activity):


### PR DESCRIPTION
Add compliance hooks for fitbit behavior which deviates from default behavior expected by authlib.
    
Regarding refreshing the token:
* Remove our custom decorator which was refreshing the token upon a 401 error to a resource request.
* When we get/refresh our access token, save it in the db with an expiration date which is a few minutes sooner than the real one. This will help ensure that we'll fetch a new token when we want to do a resource request and our token is about to expire.