### PR TITLE
Update dependencies.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,12 +1,11 @@
 -r prod.txt
-black==23.3.0
-factory-boy==3.2.1
-httpx==0.24.1
-isort==5.12.0
-pytest-asyncio==0.21.1
-pytest-cov==4.0.0
-pytest-factoryboy==2.5.1
+black==23.12.1
+factory-boy==3.3.0
+isort==5.13.2
+pytest-asyncio==0.23.3
+pytest-cov==4.1.0
+pytest-factoryboy==2.6.0
 pytest-sqlalchemy-mock==0.1.5
-pytest==7.3.1
-respx==0.20.1
-ruff==0.0.263
+pytest==7.4.4
+respx==0.20.2
+ruff==0.1.14

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,11 +1,11 @@
 Authlib==1.3.0
-SQLAlchemy[asyncio]==2.0.18
-alembic==1.10.4
+SQLAlchemy[asyncio]==2.0.25
+alembic==1.13.1
 aiosqlite==0.19.0
-fastapi==0.95.1
+fastapi==0.109.0
 pydantic==1.10.7
 python-dotenv==1.0.0
 python-multipart==0.0.6
-httpx==0.24.1
-uvicorn==0.22.0
+httpx==0.26.0
+uvicorn==0.26.0
 itsdangerous==2.1.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,7 +3,8 @@ SQLAlchemy[asyncio]==2.0.25
 alembic==1.13.1
 aiosqlite==0.19.0
 fastapi==0.109.0
-pydantic==1.10.7
+pydantic==2.5.3
+pydantic-settings==2.1.0
 python-dotenv==1.0.0
 python-multipart==0.0.6
 httpx==0.26.0

--- a/slackhealthbot/logger.py
+++ b/slackhealthbot/logger.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 from uuid import uuid4
 
 from fastapi import Request, Response
-from pydantic.utils import deep_update
+from pydantic.v1.utils import deep_update
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 from uvicorn.config import LOGGING_CONFIG

--- a/slackhealthbot/main.py
+++ b/slackhealthbot/main.py
@@ -129,11 +129,11 @@ async def withings_oauth_webhook(request: Request, db: AsyncSession = Depends(ge
 
 
 class FitbitNotification(BaseModel):
-    collectionType: Optional[str]
-    date: Optional[datetime.date]
-    ownerId: Optional[str]
-    ownerType: Optional[str]
-    subscriptionId: Optional[str]
+    collectionType: Optional[str] = None
+    date: Optional[datetime.date] = None
+    ownerId: Optional[str] = None
+    ownerType: Optional[str] = None
+    subscriptionId: Optional[str] = None
 
 
 last_processed_fitbit_notification_per_user: dict[str, datetime.datetime] = {}

--- a/slackhealthbot/services/fitbit/parser.py
+++ b/slackhealthbot/services/fitbit/parser.py
@@ -139,7 +139,7 @@ def parse_activity(input: str) -> Optional[svc_models.ActivityData]:
         type_id=fitbit_activity.activityTypeId,
         name=fitbit_activity.activityName,
         calories=fitbit_activity.calories,
-        total_minutes=fitbit_activity.duration / 60000,
+        total_minutes=fitbit_activity.duration // 60000,
         zone_minutes=[
             svc_models.ActivityZoneMinutes(zone=x.type.lower(), minutes=x.minutes)
             for x in fitbit_activity.activeZoneMinutes.minutesInHeartRateZones

--- a/slackhealthbot/services/fitbit/service.py
+++ b/slackhealthbot/services/fitbit/service.py
@@ -42,7 +42,7 @@ async def save_new_activity_data(
         fitbit_user_id=user.fitbit.id,
         type_id=activity_data.type_id,
         data={
-            **activity_data.dict(include={"log_id", "total_minutes", "calories"}),
+            **activity_data.model_dump(include={"log_id", "total_minutes", "calories"}),
             **{f"{x.zone}_minutes": x.minutes for x in activity_data.zone_minutes},
         },
     )

--- a/slackhealthbot/services/slack.py
+++ b/slackhealthbot/services/slack.py
@@ -19,7 +19,7 @@ async def post_weight(weight_data: WeightData):
     )
     async with httpx.AsyncClient() as client:
         await client.post(
-            url=settings.slack_webhook_url,
+            url=str(settings.slack_webhook_url),
             json={
                 "text": message,
             },
@@ -133,7 +133,7 @@ async def post_sleep(
     """.strip()
     async with httpx.AsyncClient() as client:
         await client.post(
-            url=settings.slack_webhook_url,
+            url=str(settings.slack_webhook_url),
             json={
                 "text": message,
             },
@@ -184,7 +184,7 @@ New {activity.name} activity from <@{slack_alias}>:
     )
     async with httpx.AsyncClient() as client:
         await client.post(
-            url=settings.slack_webhook_url,
+            url=str(settings.slack_webhook_url),
             json={
                 "text": message.strip(),
             },
@@ -199,7 +199,7 @@ You'll need to log in again to get your reports:
 """
     async with httpx.AsyncClient() as client:
         await client.post(
-            url=settings.slack_webhook_url,
+            url=str(settings.slack_webhook_url),
             json={
                 "text": message,
             },

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from pydantic import AnyHttpUrl, BaseSettings, HttpUrl
+from pydantic import AnyHttpUrl, HttpUrl
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -27,9 +28,7 @@ class Settings(BaseSettings):
         # 1071,   # Outdoor Bike
     ]
     slack_webhook_url: HttpUrl
-
-    class Config:
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 
 settings = Settings()

--- a/tests/routes/test_fitbit_routes.py
+++ b/tests/routes/test_fitbit_routes.py
@@ -77,7 +77,7 @@ async def test_sleep_notification(
             [
                 {
                     "ownerId": user.fitbit.oauth_userid,
-                    "date": 1683894606,
+                    "date": "2023-05-12",
                     "collectionType": "sleep",
                 }
             ]
@@ -153,7 +153,7 @@ async def test_activity_notification(
             [
                 {
                     "ownerId": user.fitbit.oauth_userid,
-                    "date": 1683894606,
+                    "date": "2023-05-12",
                     "collectionType": "activities",
                 }
             ]
@@ -253,7 +253,7 @@ async def test_refresh_token(
             [
                 {
                     "ownerId": user.fitbit.oauth_userid,
-                    "date": 1683894606,
+                    "date": "2023-05-12",
                     "collectionType": "activities",
                 }
             ]


### PR DESCRIPTION
The update from pydantic 1 to 2 needs some adjustments:

    
* Apply the migration tool `bump-pydantic`: https://docs.pydantic.dev/latest/migration/
* Correct some usage of types: 
    * Convert pydantic `Url` types to `str` before using them.
    * Use int, not float, for types expecting ints.
    * In tests, provide the expected date formatted string (YYYY-MM-DD) instead of a unix timestamp.
    * Use `model_dump()` instead of `dict()`.