### PR TITLE
Fix various pycharm warnings.

### DIFF
--- a/slackhealthbot/data/repositories/fitbitrepository.py
+++ b/slackhealthbot/data/repositories/fitbitrepository.py
@@ -355,6 +355,7 @@ async def get_top_activity_stats_by_user_and_activity_type(
         for column in columns
     ]
     results = await db.execute(statement=select(*subqueries))
+    # noinspection PyProtectedMember
     row = results.one()._asdict()
 
     return TopActivityStats(**row)

--- a/slackhealthbot/domain/modelmappers/remoteservicetodomain/activity.py
+++ b/slackhealthbot/domain/modelmappers/remoteservicetodomain/activity.py
@@ -1,4 +1,8 @@
-from slackhealthbot.domain.models.activity import ActivityData, ActivityZoneMinutes
+from slackhealthbot.domain.models.activity import (
+    ActivityData,
+    ActivityZone,
+    ActivityZoneMinutes,
+)
 from slackhealthbot.remoteservices.fitbit.activityapi import FitbitActivities
 
 
@@ -15,7 +19,7 @@ def remote_service_activity_to_domain_activity(
         calories=fitbit_activity.calories,
         total_minutes=fitbit_activity.duration // 60000,
         zone_minutes=[
-            ActivityZoneMinutes(zone=x.type.lower(), minutes=x.minutes)
+            ActivityZoneMinutes(zone=ActivityZone[x.type.upper()], minutes=x.minutes)
             for x in fitbit_activity.activeZoneMinutes.minutesInHeartRateZones
             if x.minutes > 0
         ],

--- a/slackhealthbot/domain/modelmappers/repositorytodomain/activity.py
+++ b/slackhealthbot/domain/modelmappers/repositorytodomain/activity.py
@@ -20,7 +20,7 @@ def repository_activity_to_domain_activity(
         total_minutes=repo.total_minutes,
         zone_minutes=[
             ActivityZoneMinutes(
-                zone=x,
+                zone=ActivityZone[x.upper()],
                 minutes=getattr(repo, f"{x}_minutes"),
             )
             for x in ActivityZone
@@ -41,7 +41,7 @@ def repository_top_activity_stats_to_domain_activity(
         total_minutes=repo.top_total_minutes,
         zone_minutes=[
             ActivityZoneMinutes(
-                zone=x,
+                zone=ActivityZone[x.upper()],
                 minutes=getattr(repo, f"top_{x}_minutes"),
             )
             for x in ActivityZone

--- a/slackhealthbot/domain/usecases/fitbit/usecase_get_last_activity.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_get_last_activity.py
@@ -13,7 +13,7 @@ from slackhealthbot.remoteservices.fitbit import activityapi
 async def do(
     db: AsyncSession,
     fitbit_userid: str,
-    when: datetime.date,
+    when: datetime.datetime,
 ) -> ActivityData | None:
     user: fitbitrepository.User = await fitbitrepository.get_user_by_fitbit_userid(
         db,

--- a/slackhealthbot/domain/usecases/fitbit/usecase_process_new_activity.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_process_new_activity.py
@@ -19,8 +19,8 @@ from slackhealthbot.settings import settings
 async def do(
     db: AsyncSession,
     fitbit_userid: str,
-    when: datetime.date,
-) -> ActivityData:
+    when: datetime.datetime,
+) -> ActivityData | None:
     user_identity: fitbitrepository.UserIdentity = (
         await fitbitrepository.get_user_identity_by_fitbit_userid(
             db,
@@ -101,7 +101,7 @@ async def _is_new_valid_activity(
     db: AsyncSession,
     fitbit_userid: str,
     type_id: int,
-    log_id: str,
+    log_id: int,
 ) -> bool:
     return (
         type_id in settings.fitbit_activity_type_ids

--- a/slackhealthbot/domain/usecases/fitbit/usecase_process_new_sleep.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_process_new_sleep.py
@@ -18,7 +18,7 @@ async def do(
     db: AsyncSession,
     fitbit_userid: str,
     when: datetime.date,
-) -> SleepData:
+) -> SleepData | None:
     user_identity: fitbitrepository.UserIdentity = (
         await fitbitrepository.get_user_identity_by_fitbit_userid(
             db,

--- a/slackhealthbot/domain/usecases/slack/usecase_post_sleep.py
+++ b/slackhealthbot/domain/usecases/slack/usecase_post_sleep.py
@@ -76,8 +76,8 @@ def get_seconds_change_icon(seconds_change: int) -> str:
     return "➡️"
 
 
-def format_time(input: datetime.datetime) -> str:
-    return input.strftime("%-H:%M")
+def format_time(dt: datetime.datetime) -> str:
+    return dt.strftime("%-H:%M")
 
 
 def format_minutes(total_minutes: int) -> str:

--- a/slackhealthbot/oauth/fitbitconfig.py
+++ b/slackhealthbot/oauth/fitbitconfig.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Coroutine
 
 from authlib.integrations.httpx_client.oauth2_client import AsyncOAuth2Client
 from fastapi import status
@@ -31,7 +31,7 @@ def is_auth_failure(response) -> bool:
     return response.status_code != status.HTTP_200_OK
 
 
-def configure(update_token_callback: Callable[[dict[str, Any]], None]):
+def configure(update_token_callback: Callable[[dict[str, Any]], Coroutine]):
     oauth.register(
         name=settings.name,
         api_base_url=settings.base_url,

--- a/slackhealthbot/oauth/withingsconfig.py
+++ b/slackhealthbot/oauth/withingsconfig.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Coroutine
 
 from authlib.common.urls import add_params_to_qs
 from authlib.integrations.httpx_client.oauth2_client import AsyncOAuth2Client
@@ -48,7 +48,7 @@ def is_auth_failure(response) -> bool:
     return False
 
 
-def configure(update_token_callback: Callable[[dict[str, Any]], None]):
+def configure(update_token_callback: Callable[[dict[str, Any]], Coroutine]):
     oauth.register(
         name=settings.name,
         api_base_url=settings.base_url,

--- a/slackhealthbot/remoteservices/fitbit/activityapi.py
+++ b/slackhealthbot/remoteservices/fitbit/activityapi.py
@@ -34,8 +34,8 @@ class FitbitActivities(BaseModel):
     activities: list[FitbitActivity]
 
     @classmethod
-    def parse(cls, input: str) -> Self:
-        return cls(**json.loads(input))
+    def parse(cls, text: bytes) -> Self:
+        return cls(**json.loads(text))
 
 
 async def get_activity(

--- a/slackhealthbot/remoteservices/fitbit/sleepapi.py
+++ b/slackhealthbot/remoteservices/fitbit/sleepapi.py
@@ -57,9 +57,9 @@ class FitbitSleep(BaseModel):
     ]
 
     @classmethod
-    def parse(cls, input: str) -> Self:
-        logging.info(f"parse sleep input: {input}")
-        return cls(**json.loads(input))
+    def parse(cls, text: bytes | str) -> Self:
+        logging.info(f"parse sleep input: {text}")
+        return cls(**json.loads(text))
 
 
 async def get_sleep(

--- a/slackhealthbot/routers/dependencies.py
+++ b/slackhealthbot/routers/dependencies.py
@@ -9,7 +9,7 @@ async def get_db():
         # We need to access the db session without having access to
         # fastapi's dependency injection. This happens when our update_token()
         # authlib function is called.
-        # Set the db in a ContextVar to allow accessing it outside of a fastapi route.
+        # Set the db in a ContextVar to allow accessing it outside a fastapi route.
         ctx_db.set(db)
         yield db
     finally:

--- a/tests/domain/modelmappers/remoteservicetodomain/test_remote_service_sleep_to_domain_sleep.py
+++ b/tests/domain/modelmappers/remoteservicetodomain/test_remote_service_sleep_to_domain_sleep.py
@@ -55,6 +55,6 @@ def test_parse_sleep(input_filename: str, expected_sleep_data: SleepData):
         / input_filename
     )
     with open(input_file) as input:
-        api_data: FitbitSleep = FitbitSleep.parse(input=input.read())
+        api_data: FitbitSleep = FitbitSleep.parse(text=input.read())
         actual_sleep_data = remote_service_sleep_to_domain_sleep(api_data)
         assert actual_sleep_data == expected_sleep_data


### PR DESCRIPTION
* Fix some type hints
* Suppress warning about acessing `_asdict()` in sqlalchemy. It's [documented](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row._asdict).
* Avoid using `input` as a variable/argument name, as it's a built-in symbol.
* Define a method as `@staticmethod` if it doesn't need to access any class or instance fields.
* ~Add missing `await` before a call of an async function.~ Fixed in #61
* Convert str explicitly to `ActivityZone` enum instances, where enum instances are expected.