### PR TITLE
Fix some more pycharm warnings (in test code).

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,11 @@ def setup_factories(mocked_session):
         FitbitUserFactory,
         FitbitActivityFactory,
     ]:
+        # The _meta attribute is documented:
+        # https://factoryboy.readthedocs.io/en/stable/reference.html#factory.Factory._meta
+        # noinspection PyProtectedMember
         factory._meta.sqlalchemy_session = mocked_session
+        # noinspection PyProtectedMember
         factory._meta.sqlalchemy_session_persistence = "commit"
 
 

--- a/tests/data/repositories/test_fitbitrepository.py
+++ b/tests/data/repositories/test_fitbitrepository.py
@@ -25,7 +25,7 @@ async def test_top_activities(
     recent_date = datetime.datetime(2024, 1, 2, 23, 44, 55)
     old_date = datetime.datetime(2023, 3, 4, 15, 44, 33)
 
-    # Our user, our activity, all time top record for calories
+    # Our user, our activity, all-time top record for calories
     all_time_top_calories_activity: models.FitbitActivity = fitbit_activity_factory(
         fitbit_user_id=user.fitbit.id,
         type_id=activity_type,
@@ -49,7 +49,7 @@ async def test_top_activities(
         updated_at=recent_date,
     )
 
-    # Our user, our activity, all time top record for the different minutes attributes
+    # Our user, our activity, all-time top record for the different minutes attributes
     all_time_top_minutes_activity: models.FitbitActivity = fitbit_activity_factory(
         fitbit_user_id=user.fitbit.id,
         type_id=activity_type,

--- a/tests/data/repositories/test_fitbitrepository.py
+++ b/tests/data/repositories/test_fitbitrepository.py
@@ -19,50 +19,56 @@ async def test_top_activities(
 ):
     user_factory, _, fitbit_activity_factory = fitbit_factories
     activity_type = 111
-    user: models.User = user_factory()
-    other_user: models.User = user_factory()
+    user: models.User = user_factory.create()
+    other_user: models.User = user_factory.create()
 
     recent_date = datetime.datetime(2024, 1, 2, 23, 44, 55)
     old_date = datetime.datetime(2023, 3, 4, 15, 44, 33)
 
     # Our user, our activity, all-time top record for calories
-    all_time_top_calories_activity: models.FitbitActivity = fitbit_activity_factory(
-        fitbit_user_id=user.fitbit.id,
-        type_id=activity_type,
-        calories=600,
-        total_minutes=18,
-        fat_burn_minutes=17,
-        cardio_minutes=16,
-        peak_minutes=15,
-        updated_at=old_date,
+    all_time_top_calories_activity: models.FitbitActivity = (
+        fitbit_activity_factory.create(
+            fitbit_user_id=user.fitbit.id,
+            type_id=activity_type,
+            calories=600,
+            total_minutes=18,
+            fat_burn_minutes=17,
+            cardio_minutes=16,
+            peak_minutes=15,
+            updated_at=old_date,
+        )
     )
 
     # Our user, our activity, recent top record for calories
-    recent_top_calories_activity: models.FitbitActivity = fitbit_activity_factory(
-        fitbit_user_id=user.fitbit.id,
-        type_id=activity_type,
-        calories=599,
-        total_minutes=18,
-        fat_burn_minutes=17,
-        cardio_minutes=16,
-        peak_minutes=15,
-        updated_at=recent_date,
+    recent_top_calories_activity: models.FitbitActivity = (
+        fitbit_activity_factory.create(
+            fitbit_user_id=user.fitbit.id,
+            type_id=activity_type,
+            calories=599,
+            total_minutes=18,
+            fat_burn_minutes=17,
+            cardio_minutes=16,
+            peak_minutes=15,
+            updated_at=recent_date,
+        )
     )
 
     # Our user, our activity, all-time top record for the different minutes attributes
-    all_time_top_minutes_activity: models.FitbitActivity = fitbit_activity_factory(
-        fitbit_user_id=user.fitbit.id,
-        type_id=activity_type,
-        calories=333,
-        total_minutes=30,
-        fat_burn_minutes=29,
-        cardio_minutes=28,
-        peak_minutes=27,
-        updated_at=old_date,
+    all_time_top_minutes_activity: models.FitbitActivity = (
+        fitbit_activity_factory.create(
+            fitbit_user_id=user.fitbit.id,
+            type_id=activity_type,
+            calories=333,
+            total_minutes=30,
+            fat_burn_minutes=29,
+            cardio_minutes=28,
+            peak_minutes=27,
+            updated_at=old_date,
+        )
     )
 
     # Our user, our activity, recent top record for the different minutes attributes
-    recent_top_minutes_activity: models.FitbitActivity = fitbit_activity_factory(
+    recent_top_minutes_activity: models.FitbitActivity = fitbit_activity_factory.create(
         fitbit_user_id=user.fitbit.id,
         type_id=activity_type,
         calories=333,
@@ -74,7 +80,7 @@ async def test_top_activities(
     )
 
     # Our user, but not top stats
-    fitbit_activity_factory(
+    fitbit_activity_factory.create(
         fitbit_user_id=user.fitbit.id,
         type_id=activity_type,
         calories=400,
@@ -86,7 +92,7 @@ async def test_top_activities(
     )
 
     # Another user with higher stats
-    fitbit_activity_factory(
+    fitbit_activity_factory.create(
         fitbit_user_id=other_user.fitbit.id,
         type_id=activity_type,
         calories=800,
@@ -98,7 +104,7 @@ async def test_top_activities(
     )
 
     # Our user, with higher stats for another activity type
-    fitbit_activity_factory(
+    fitbit_activity_factory.create(
         fitbit_user_id=user.fitbit.id,
         type_id=999,
         calories=900,
@@ -148,7 +154,7 @@ async def test_top_activities_no_history(
 ):
     user_factory, _, _ = fitbit_factories
     activity_type = 111
-    user: models.User = user_factory()
+    user: models.User = user_factory.create()
     recent_date = datetime.datetime(2024, 1, 2, 23, 44, 55)
 
     all_time_top_activity_stats: fitbitrepository.TopActivityStats = (

--- a/tests/domain/modelmappers/remoteservicetodomain/test_remote_service_sleep_to_domain_sleep.py
+++ b/tests/domain/modelmappers/remoteservicetodomain/test_remote_service_sleep_to_domain_sleep.py
@@ -54,7 +54,7 @@ def test_parse_sleep(input_filename: str, expected_sleep_data: SleepData):
         / "fixtures"
         / input_filename
     )
-    with open(input_file) as input:
-        api_data: FitbitSleep = FitbitSleep.parse(text=input.read())
+    with open(input_file) as sleep_input:
+        api_data: FitbitSleep = FitbitSleep.parse(text=sleep_input.read())
         actual_sleep_data = remote_service_sleep_to_domain_sleep(api_data)
         assert actual_sleep_data == expected_sleep_data

--- a/tests/domain/usecases/slack/test_usecase_post_activity.py
+++ b/tests/domain/usecases/slack/test_usecase_post_activity.py
@@ -28,7 +28,7 @@ from slackhealthbot.domain.usecases.slack import usecase_post_activity
     ],
 )
 def test_get_activity_minutes_change_icon(
-    input_value: str,
+    input_value: int,
     expected_output: str,
 ):
     actual_output = usecase_post_activity.get_activity_minutes_change_icon(input_value)
@@ -51,7 +51,7 @@ def test_get_activity_minutes_change_icon(
     ],
 )
 def test_get_activity_calories_change_icon(
-    input_value: str,
+    input_value: int,
     expected_output: str,
 ):
     actual_output = usecase_post_activity.get_activity_calories_change_icon(input_value)
@@ -113,7 +113,8 @@ CREATE_MESSAGE_SCENARIOS = [
                 ),
             ],
         ),
-        expected_message_regex="^.* ⬆️ New all-time record! 🏆.* ⬆️ New all-time record! 🏆.* ⬆️ New all-time record! 🏆.* ⬆️ New all-time record! 🏆$",
+        expected_message_regex="^.* ⬆️ New all-time record! 🏆.* ⬆️ New all-time record! 🏆.* ⬆️ New all-time record! "
+        "🏆.* ⬆️ New all-time record! 🏆$",
     ),
     CreateMessageScenario(
         name="recent top record",
@@ -134,7 +135,8 @@ CREATE_MESSAGE_SCENARIOS = [
                 ),
             ],
         ),
-        expected_message_regex="^.* ⬆️ New record \(last 30 days\)! 🏆.* ➡️ New record \(last 30 days\)! 🏆.* ⬆️ New record \(last 30 days\)! 🏆.* ➡️ New record \(last 30 days\)! 🏆$",
+        expected_message_regex="^.* ⬆️ New record \\(last 30 days\\)! 🏆.* ➡️ New record \\(last 30 days\\)! 🏆.* ⬆️ New "
+        "record \\(last 30 days\\)! 🏆.* ➡️ New record \\(last 30 days\\)! 🏆$",
     ),
     CreateMessageScenario(
         name="lowest score",

--- a/tests/domain/usecases/slack/test_usecase_post_sleep.py
+++ b/tests/domain/usecases/slack/test_usecase_post_sleep.py
@@ -9,7 +9,7 @@ from slackhealthbot.domain.usecases.slack import usecase_post_sleep
 
 
 @pytest.mark.parametrize(
-    "input,expected_output",
+    "input_minutes,expected_output",
     [
         (55, "55m"),
         (65, "1h 5m"),
@@ -17,20 +17,20 @@ from slackhealthbot.domain.usecases.slack import usecase_post_sleep
         (721, "12h 1m"),
     ],
 )
-def test_format_minutes(input: int, expected_output: str):
-    actual_output = usecase_post_sleep.format_minutes(input)
+def test_format_minutes(input_minutes: int, expected_output: str):
+    actual_output = usecase_post_sleep.format_minutes(input_minutes)
     assert actual_output == expected_output
 
 
 @pytest.mark.parametrize(
-    "input,expected_output",
+    "input_datetime,expected_output",
     [
         (datetime.datetime(2023, 5, 14, 1, 51, 33, 234), "1:51"),
         (datetime.datetime(2023, 5, 14, 15, 51, 33, 234), "15:51"),
     ],
 )
-def test_format_time(input: datetime.datetime, expected_output: str):
-    actual_output = usecase_post_sleep.format_time(input)
+def test_format_time(input_datetime: datetime.datetime, expected_output: str):
+    actual_output = usecase_post_sleep.format_time(input_datetime)
     assert actual_output == expected_output
 
 

--- a/tests/routes/test_fitbit_oauth.py
+++ b/tests/routes/test_fitbit_oauth.py
@@ -47,8 +47,8 @@ async def test_refresh_token_ok(
     ]
 
     # Given a user
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_access_token="some old access token",
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
@@ -157,8 +157,8 @@ async def test_refresh_token_fail(
     ]
 
     # Given a user
-    user: User = user_factory(fitbit=None, slack_alias="jdoe")
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None, slack_alias="jdoe")
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_access_token="some old invalid access token",
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
@@ -242,13 +242,13 @@ async def test_login_success(
 
     # Given a user
     if scenario == LoginScenario.EXISTING_FITBIT_USER:
-        user: User = user_factory(fitbit=None, slack_alias="jdoe")
-        fitbit_user_factory(
+        user: User = user_factory.create(fitbit=None, slack_alias="jdoe")
+        fitbit_user_factory.create(
             user_id=user.id,
             oauth_userid="user123",
         )
     elif scenario == LoginScenario.EXISTING_NOT_FITBIT_USER:
-        user_factory(fitbit=None, slack_alias="jdoe")
+        user_factory.create(fitbit=None, slack_alias="jdoe")
 
     # mock authlib's generation of a URL on fitbit
     async def mock_authorize_redirect(*_args, **_kwags):
@@ -335,8 +335,8 @@ async def test_logged_out(
     activity_type_id = 55001
 
     # Given a user
-    user: User = user_factory(fitbit=None, slack_alias="jdoe")
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None, slack_alias="jdoe")
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_access_token="some invalid access token",
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)

--- a/tests/routes/test_fitbit_oauth.py
+++ b/tests/routes/test_fitbit_oauth.py
@@ -34,7 +34,7 @@ async def test_refresh_token_ok(
     Given a user whose access token is expired
     When we receive the callback from fitbit that a new activity is available
     Then the access token is refreshed
-    And the latest activity is updated in the database
+    And the latest activity is updated in the database,
     And the message is posted to slack with the correct pattern.
     """
 
@@ -144,7 +144,7 @@ async def test_refresh_token_fail(
     Given a user whose access token is expired and invalid
     When we receive the callback from fitbit that a new activity is available
     Then the access token refresh fails
-    And no latest activity is updated in the database
+    And no latest activity is updated in the database,
     And the message is posted to slack about the user being logged out
     """
 
@@ -250,8 +250,8 @@ async def test_login_success(
     elif scenario == LoginScenario.EXISTING_NOT_FITBIT_USER:
         user_factory(fitbit=None, slack_alias="jdoe")
 
-    # mock authlib's generation of a url on fitbit
-    async def mock_authorize_redirect(fake_self, request):
+    # mock authlib's generation of a URL on fitbit
+    async def mock_authorize_redirect(*_args, **_kwags):
         return RedirectResponse("https://fakefitbit.com", status_code=302)
 
     monkeypatch.setattr(
@@ -269,7 +269,7 @@ async def test_login_success(
     assert response.headers["location"] == "https://fakefitbit.com"
 
     # mock authlib's token response
-    async def mock_authorize_access_token(fake_self, request):
+    async def mock_authorize_access_token(*_args, **_kwargs):
         return {
             "userid": "user123",
             "access_token": "some access token",
@@ -284,7 +284,7 @@ async def test_login_success(
     )
 
     # Simulate fitbit's response to the sleep and activity subscriptions
-    async def mock_post(fake_self, *args, **kwargs):
+    async def mock_post(*_args, **_kwargs):
         return Response(status_code=200, json={})
 
     monkeypatch.setattr(

--- a/tests/routes/test_fitbit_routes.py
+++ b/tests/routes/test_fitbit_routes.py
@@ -48,8 +48,8 @@ async def test_sleep_notification(
     user_factory, fitbit_user_factory, _ = fitbit_factories
 
     # Given a user with the given previous sleep data
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         **scenario.input_initial_sleep_data,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
@@ -124,15 +124,15 @@ async def test_activity_notification(
     activity_type_id = 55001
 
     # Given a user with the given previous activity data
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
         + datetime.timedelta(days=1),
     )
 
     if scenario.input_initial_activity_data:
-        fitbit_activity_factory(
+        fitbit_activity_factory.create(
             fitbit_user_id=fitbit_user.id,
             type_id=activity_type_id,
             **scenario.input_initial_activity_data,
@@ -212,8 +212,8 @@ async def test_duplicate_activity_notification(
     ]
 
     # Given a user with the given previous activity data
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
         + datetime.timedelta(days=1),
@@ -303,8 +303,8 @@ async def test_duplicate_sleep_notification(
     scenario: FitbitSleepScenario = sleep_scenarios["No previous sleep data"]
 
     # Given a user with the given previous sleep data
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         **scenario.input_initial_sleep_data,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)

--- a/tests/routes/test_fitbit_routes.py
+++ b/tests/routes/test_fitbit_routes.py
@@ -41,7 +41,7 @@ async def test_sleep_notification(
     """
     Given a user with a given previous sleep logged
     When we receive the callback from fitbit that a new sleep is available
-    Then the last sleep is updated in the database
+    Then the last sleep is updated in the database,
     And the message is posted to slack with the correct icons.
     """
 
@@ -116,7 +116,7 @@ async def test_activity_notification(
     """
     Given a user with a given previous activity logged
     When we receive the callback from fitbit that a new activity is available
-    Then the latest activity is updated in the database
+    Then the latest activity is updated in the database,
     And the message is posted to slack with the correct pattern.
     """
 
@@ -201,7 +201,7 @@ async def test_duplicate_activity_notification(
     """
     Given a user
     When we receive the callback twice from fitbit that a new activity is available
-    Then the latest activity is updated in the database
+    Then the latest activity is updated in the database,
     And the message is posted to slack only once with the correct pattern.
     """
 
@@ -295,12 +295,12 @@ async def test_duplicate_sleep_notification(
     """
     Given a user
     When we receive the callback twice from fitbit that a new sleep is available
-    Then the latest sleep is updated in the database
+    Then the latest sleep is updated in the database,
     And the message is posted to slack only once with the correct pattern.
     """
 
     user_factory, fitbit_user_factory, _ = fitbit_factories
-    scenario: FitbitActivityScenario = sleep_scenarios["No previous sleep data"]
+    scenario: FitbitSleepScenario = sleep_scenarios["No previous sleep data"]
 
     # Given a user with the given previous sleep data
     user: User = user_factory(fitbit=None)

--- a/tests/routes/test_withings_oauth.py
+++ b/tests/routes/test_withings_oauth.py
@@ -38,8 +38,8 @@ async def test_refresh_token_ok(
 
     ctx_db.set(mocked_async_session)
     # Given a user
-    user: User = user_factory(withings=None)
-    db_withings_user: DbWithingsUser = withings_user_factory(
+    user: User = user_factory.create(withings=None)
+    db_withings_user: DbWithingsUser = withings_user_factory.create(
         user_id=user.id,
         last_weight=50.2,
         oauth_access_token="some old access token",
@@ -149,8 +149,8 @@ async def test_refresh_token_fail(
 
     ctx_db.set(mocked_async_session)
     # Given a user
-    user: User = user_factory(withings=None, slack_alias="jdoe")
-    db_withings_user: DbWithingsUser = withings_user_factory(
+    user: User = user_factory.create(withings=None, slack_alias="jdoe")
+    db_withings_user: DbWithingsUser = withings_user_factory.create(
         user_id=user.id,
         last_weight=None,
         oauth_access_token="some old invalid access token",
@@ -231,13 +231,13 @@ async def test_login_success(
     ctx_db.set(mocked_async_session)
     # Given a user
     if scenario == LoginScenario.EXISTING_WITHINGS_USER:
-        user: User = user_factory(withings=None, slack_alias="jdoe")
-        withings_user_factory(
+        user: User = user_factory.create(withings=None, slack_alias="jdoe")
+        withings_user_factory.create(
             user_id=user.id,
             oauth_userid="user123",
         )
     elif scenario == LoginScenario.EXISTING_NOT_WITHINGS_USER:
-        user_factory(withings=None, slack_alias="jdoe")
+        user_factory.create(withings=None, slack_alias="jdoe")
 
     # mock authlib's generation of a URL on withings
     async def mock_authorize_redirect(*_args, **_kwargs):
@@ -322,8 +322,8 @@ async def test_logged_out(
 
     ctx_db.set(mocked_async_session)
     # Given a user
-    user: User = user_factory(withings=None, slack_alias="jdoe")
-    db_withings_user: DbWithingsUser = withings_user_factory(
+    user: User = user_factory.create(withings=None, slack_alias="jdoe")
+    db_withings_user: DbWithingsUser = withings_user_factory.create(
         user_id=user.id,
         last_weight=None,
         oauth_access_token="some invalid access token",

--- a/tests/routes/test_withings_oauth.py
+++ b/tests/routes/test_withings_oauth.py
@@ -31,7 +31,7 @@ async def test_refresh_token_ok(
     Given a user whose access token is expired
     When we receive the callback from withings that a new weight is available
     Then the access token is refreshed
-    And the latest weight is updated in the database
+    And the latest weight is updated in the database,
     And the message is posted to slack with the correct pattern.
     """
     user_factory, withings_user_factory = withings_factories
@@ -142,7 +142,7 @@ async def test_refresh_token_fail(
     Given a user whose access token is expired and invalid
     When we receive the callback from withings that a new weight is available
     Then the access token refresh fails
-    And no weight is updated in the database
+    And no weight is updated in the database,
     And the message is posted to slack about the user being logged out
     """
     user_factory, withings_user_factory = withings_factories
@@ -239,8 +239,8 @@ async def test_login_success(
     elif scenario == LoginScenario.EXISTING_NOT_WITHINGS_USER:
         user_factory(withings=None, slack_alias="jdoe")
 
-    # mock authlib's generation of a url on withings
-    async def mock_authorize_redirect(fake_self, request, redirect_uri):
+    # mock authlib's generation of a URL on withings
+    async def mock_authorize_redirect(*_args, **_kwargs):
         return RedirectResponse("https://fakewithings.com", status_code=302)
 
     monkeypatch.setattr(
@@ -258,7 +258,7 @@ async def test_login_success(
     assert response.headers["location"] == "https://fakewithings.com"
 
     # mock authlib's token response
-    async def mock_authorize_access_token(fake_self, request):
+    async def mock_authorize_access_token(*_args, **_kwargs):
         return {
             "userid": "user123",
             "access_token": "some access token",
@@ -273,7 +273,7 @@ async def test_login_success(
     )
 
     # Simulate withings's response to the sleep and activity subscriptions
-    async def mock_post(fake_self, *args, **kwargs):
+    async def mock_post(*_args, **_kwargs):
         return Response(status_code=200, json={"status": 0})
 
     monkeypatch.setattr(

--- a/tests/routes/test_withings_routes.py
+++ b/tests/routes/test_withings_routes.py
@@ -53,8 +53,8 @@ async def test_weight_notification(
     user_factory, withings_user_factory = withings_factories
 
     # Given a user
-    user: User = user_factory(withings=None)
-    db_withings_user: DbWithingsUser = withings_user_factory(
+    user: User = user_factory.create(withings=None)
+    db_withings_user: DbWithingsUser = withings_user_factory.create(
         user_id=user.id,
         last_weight=scenario.input_initial_weight,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
@@ -140,8 +140,8 @@ async def test_duplicate_weight_notification(
     user_factory, withings_user_factory = withings_factories
 
     # Given a user
-    user: User = user_factory(withings=None)
-    db_withings_user: DbWithingsUser = withings_user_factory(
+    user: User = user_factory.create(withings=None)
+    db_withings_user: DbWithingsUser = withings_user_factory.create(
         user_id=user.id,
         last_weight=50.2,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)

--- a/tests/routes/test_withings_routes.py
+++ b/tests/routes/test_withings_routes.py
@@ -46,7 +46,7 @@ async def test_weight_notification(
     """
     Given a user with a given previous weight logged
     When we receive the callback from withings that a new weight is available
-    Then the last_weight is updated in the database
+    Then the last_weight is updated in the database,
     And the message is posted to slack with the correct icon.
     """
 
@@ -133,7 +133,7 @@ async def test_duplicate_weight_notification(
     """
     Given a user with a given previous weight logged
     When we receive the callback twice from withings that a new weight is available
-    Then the last_weight is updated in the database
+    Then the last_weight is updated in the database,
     And the message is posted to slack only once
     """
 

--- a/tests/tasks/test_fitbit_oauth.py
+++ b/tests/tasks/test_fitbit_oauth.py
@@ -32,7 +32,7 @@ async def test_refresh_token_ok(
     Given a user whose access token is expired
     When we poll fitbit for a new activity
     Then the access token is refreshed
-    And the latest activity is updated in the database
+    And the latest activity is updated in the database,
     And the message is posted to slack with the correct pattern.
     """
 
@@ -138,7 +138,7 @@ async def test_refresh_token_fail(
     Given a user whose access token is expired and invalid
     When we poll fitbit for new activity
     Then the access token refresh fails
-    And no latest activity is updated in the database
+    And no latest activity is updated in the database,
     And the message is posted to slack about the user being logged out
     """
 

--- a/tests/tasks/test_fitbit_oauth.py
+++ b/tests/tasks/test_fitbit_oauth.py
@@ -45,8 +45,8 @@ async def test_refresh_token_ok(
     ]
 
     # Given a user
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_access_token="some old access token",
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
@@ -151,8 +151,8 @@ async def test_refresh_token_fail(
     ]
 
     # Given a user
-    user: User = user_factory(fitbit=None, slack_alias="jdoe")
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None, slack_alias="jdoe")
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_access_token="some old invalid access token",
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
@@ -232,8 +232,8 @@ async def test_logged_out(
     activity_type_id = 55001
 
     # Given a user
-    user: User = user_factory(fitbit=None, slack_alias="jdoe")
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None, slack_alias="jdoe")
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_access_token="some invalid access token",
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)

--- a/tests/tasks/test_fitbit_poll.py
+++ b/tests/tasks/test_fitbit_poll.py
@@ -50,8 +50,8 @@ async def test_fitbit_poll_sleep(
     user_factory, fitbit_user_factory, _ = fitbit_factories
 
     # Given a user with the given previous sleep data
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         **scenario.input_initial_sleep_data,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
@@ -122,14 +122,14 @@ async def test_fitbit_poll_activity(
     activity_type_id = 55001
 
     # Given a user with the given previous activity data
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
         + datetime.timedelta(days=1),
     )
     if scenario.input_initial_activity_data:
-        fitbit_activity_factory(
+        fitbit_activity_factory.create(
             fitbit_user_id=fitbit_user.id,
             type_id=activity_type_id,
             **scenario.input_initial_activity_data,
@@ -199,8 +199,8 @@ async def test_schedule_fitbit_poll(
 
     user_factory, fitbit_user_factory, _ = fitbit_factories
 
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
         user_id=user.id,
         oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
         + datetime.timedelta(days=1),

--- a/tests/tasks/test_fitbit_poll.py
+++ b/tests/tasks/test_fitbit_poll.py
@@ -37,14 +37,14 @@ from tests.testsupport.fixtures.fitbit_scenarios import (
 async def test_fitbit_poll_sleep(
     mocked_async_session,
     respx_mock: MockRouter,
-    fitbit_factories: tuple[UserFactory, FitbitUserFactory],
+    fitbit_factories: tuple[UserFactory, FitbitUserFactory, FitbitActivityFactory],
     scenario: FitbitSleepScenario,
     client: TestClient,
 ):
     """
     Given a user with given previous sleep data logged
     When we poll fitbit to get new sleep data
-    Then the last sleep is updated in the database
+    Then the last sleep is updated in the database,
     And the message is posted to slack with the correct icon.
     """
     user_factory, fitbit_user_factory, _ = fitbit_factories
@@ -114,7 +114,7 @@ async def test_fitbit_poll_activity(
     """
     Given a user with given previous activity data logged
     When we poll fitbit to get new activity data
-    Then the latest activity is updated in the database
+    Then the latest activity is updated in the database,
     And the message is posted to slack with the correct pattern.
     """
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -24,7 +24,7 @@ async def test_user_factory(
     user_factory: UserFactory,
     mocked_async_session,
 ):
-    user: User = user_factory()
+    user: User = user_factory.create()
     assert isinstance(user.slack_alias, str)
     assert isinstance(user.id, int)
     assert isinstance(user.withings, WithingsUser)
@@ -46,8 +46,8 @@ async def test_withings_user_factory(
     withings_user_factory: WithingsUserFactory,
     mocked_async_session,
 ):
-    user: User = user_factory(withings=None)
-    withings_user: WithingsUser = withings_user_factory(user_id=user.id)
+    user: User = user_factory.create(withings=None)
+    withings_user: WithingsUser = withings_user_factory.create(user_id=user.id)
     assert isinstance(withings_user.oauth_access_token, str)
     assert isinstance(withings_user.oauth_refresh_token, str)
     assert isinstance(withings_user.oauth_userid, str)
@@ -74,8 +74,8 @@ async def test_fitbit_user_factory(
     fitbit_user_factory: FitbitUserFactory,
     mocked_async_session: AsyncSession,
 ):
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(user_id=user.id)
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(user_id=user.id)
     assert isinstance(fitbit_user.oauth_access_token, str)
     assert isinstance(fitbit_user.oauth_refresh_token, str)
     assert isinstance(fitbit_user.oauth_userid, str)
@@ -101,9 +101,9 @@ async def test_fitbit_activity_factory(
     fitbit_activity_factory: FitbitActivityFactory,
     mocked_async_session: AsyncSession,
 ):
-    user: User = user_factory(fitbit=None)
-    fitbit_user: FitbitUser = fitbit_user_factory(user_id=user.id)
-    fitbit_activity: FitbitActivity = fitbit_activity_factory(
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(user_id=user.id)
+    fitbit_activity: FitbitActivity = fitbit_activity_factory.create(
         fitbit_user_id=fitbit_user.id
     )
     repo_activity: fitbitrepository.Activity = (

--- a/tests/testsupport/fixtures/fitbit_scenarios.py
+++ b/tests/testsupport/fixtures/fitbit_scenarios.py
@@ -7,7 +7,7 @@ from slackhealthbot.data.repositories.fitbitrepository import Sleep
 
 @dataclasses.dataclass
 class FitbitSleepScenario:
-    input_initial_sleep_data: dict[str, int]
+    input_initial_sleep_data: dict[str, int | None]
     input_mock_fitbit_response: dict[str, Any]
     expected_new_last_sleep_data: Sleep
     expected_icons: str | None
@@ -266,10 +266,10 @@ sleep_scenarios: dict[str, FitbitSleepScenario] = {
 
 @dataclasses.dataclass
 class FitbitActivityScenario:
-    input_initial_activity_data: dict[str | int] | None
+    input_initial_activity_data: dict[str, int | datetime.datetime] | None
     input_mock_fitbit_response: dict[str, Any]
     expected_new_last_activity_log_id: int
-    expected_message_pattern: str
+    expected_message_pattern: str | None
 
     @property
     def is_new_log_expected(self) -> bool:
@@ -356,7 +356,8 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
         },
         expected_new_last_activity_log_id=1235,
         expected_message_pattern=(
-            "New Spinning activity.*⬇️ New record.*⬆️ New all-time record.*Fat burn.*8.*➡.*New all-time record.*Cardio.*9.*↘️ New record"
+            "New Spinning activity.*⬇️ New record.*⬆️ New all-time record.*Fat burn.*8.*➡.*New all-time "
+            "record.*Cardio.*9.*↘️ New record"
         ),
     ),
     "New Spinning activity, full zones": FitbitActivityScenario(
@@ -404,7 +405,8 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
         },
         expected_new_last_activity_log_id=1235,
         expected_message_pattern="New Spinning activity.*↗️ New all-time record.*➡️ New all-time record.*"
-        + "Fat burn.*12.*⬆️ New all-time record.*Cardio.*9.*⬇️ New record.*Out of range.*10.*↗️.*Peak.*11.*⬆️ New all-time record",
+        + "Fat burn.*12.*⬆️ New all-time record.*Cardio.*9.*⬇️ New record.*Out of range.*10.*↗️.*Peak.*11.*⬆️ New "
+        "all-time record",
     ),
     "New unrecognized activity": FitbitActivityScenario(
         input_initial_activity_data={


### PR DESCRIPTION
* Don't use `input` as a variable/argument name, as it's a builtin symbol
* Fix some type hints
* Fix some unused arguments (when required to be present, prefix the arguments with underscore).
* Fix some grammar errors
* Use `xyz_factory.create()` instead of `xyz_factory()`.
  - See https://github.com/FactoryBoy/factory_boy/issues/468
  - PIDD: Pycharm inspection driven development 🤷
* Fix lines which are too long
* Fix regex pattern to match literal parentheses
* Suppress a pycharm warning about accessing the _meta field of a factory boy factory instance. The field is documented.