### PR TITLE
Issue #72: fix a few bugs with activity distance in km

### DIFF
--- a/slackhealthbot/domain/usecases/slack/usecase_post_activity.py
+++ b/slackhealthbot/domain/usecases/slack/usecase_post_activity.py
@@ -45,7 +45,7 @@ def create_message(
             )
             if activity.distance_km
             and activity_history.latest_activity_data.distance_km
-            else None
+            else ""
         )
 
         for zone_minutes in activity.zone_minutes:
@@ -83,8 +83,6 @@ def create_message(
             record_history_days=record_history_days,
         )
         if activity.distance_km
-        and activity_history.all_time_top_activity_data.top_distance_km
-        and activity_history.recent_top_activity_data
         else None
     )
 
@@ -117,7 +115,7 @@ New {activity_name} activity from <@{slack_alias}>:
     • Calories: {activity.calories} {calories_icon} {calories_record_text}
 """
     if activity.distance_km:
-        message += f"    • Distance: {activity.distance_km}km {distance_km_icon} {distance_km_record_text}"
+        message += f"    • Distance: {activity.distance_km:.3f} km {distance_km_icon} {distance_km_record_text}"
     message += "\n".join(
         [
             f"    • {format_activity_zone(zone_minutes.zone)}"

--- a/tests/testsupport/fixtures/fitbit_scenarios.py
+++ b/tests/testsupport/fixtures/fitbit_scenarios.py
@@ -413,6 +413,7 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
             "log_id": 1234,
             "total_minutes": 8,
             "calories": 70,
+            "distance_km": None,
             "fat_burn_minutes": 1,
             "cardio_minutes": 20,
             "out_of_range_minutes": None,
@@ -448,14 +449,14 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
                     "logId": 1235,
                     "calories": 76,
                     "duration": 665000,
-                    "distance": 1.2,
+                    "distance": 1.119999,
                     "distanceUnit": "Kilometer",
                 },
             ]
         },
         expected_new_last_activity_log_id=1235,
         expected_message_pattern="New Walking activity.*Duration.*↗️ New all-time record"
-        + ".*Calories.*76.*➡️ New all-time record.*Distance.*1.2.*"
+        + ".*Calories.*76.*➡️ New all-time record.*Distance: 1.120 km  New all-time record.*"
         + "Fat burn.*12.*⬆️ New all-time record.*Cardio.*9.*⬇️ New record.*Out of range.*10.*↗️.*Peak.*11.*⬆️ New "
         "all-time record",
     ),
@@ -500,14 +501,14 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
                     "logId": 1235,
                     "calories": 76,
                     "duration": 665000,
-                    "distance": 1.2,
+                    "distance": 1.119999,
                     "distanceUnit": "Kilometer",
                 },
             ]
         },
         expected_new_last_activity_log_id=1235,
         expected_message_pattern="New Walking activity.*Duration.*↗️ New all-time record"
-        + ".*Calories.*76.*➡️ New all-time record.*Distance.*1.2.*⬆️ New all-time record.*"
+        + ".*Calories.*76.*➡️ New all-time record.*Distance: 1.120 km.*⬆️ New all-time record.*"
         + "Fat burn.*12.*⬆️ New all-time record.*Cardio.*9.*⬇️ New record.*Out of range.*10.*↗️.*Peak.*11.*⬆️ New "
         "all-time record",
     ),


### PR DESCRIPTION
* If we don't have a previous activity of the same type with a distance:
  - don't put "None" for the trend icon. Just leave it as an empty space.
  - do display an "all time record" text.
* Display 3 digits after the decimal place.
* Add a space between the number and the "km" unit.