### PR TITLE
Issue #83 - Step 3 - Configure which fields should be reported to slack, per activity.

### DIFF
--- a/config/app-default.yaml
+++ b/config/app-default.yaml
@@ -19,6 +19,9 @@ fitbit:
   activities:
     history_days: 180 # how far to look back to report new records of best times/durations/calories/etc.
     daily_report_time: "23:50" # Time of day (HH:mm)to post daily reports to slack.
+    default_report:
+      daily: false
+      realtime: true
 
     activity_types:
       # Configuration specific to activity types.
@@ -38,15 +41,18 @@ fitbit:
       # report_realtime: whether a report should be posted to slack for this activity type as soon as we receive it from fitbit
       - name: Treadmill
         id: 90019
-        report_daily: true
-        report_realtime: false
+        report:
+          daily: true
+          realtime: false
 
       - name: Spinning
         id: 55001
-        report_daily: false
-        report_realtime: true
+        report:
+          daily: false
+          realtime: true
 
       - name: Walk
         id: 90013
-        report_daily: false
-        report_realtime: true
+        report:
+          daily: false
+          realtime: true

--- a/config/app-default.yaml
+++ b/config/app-default.yaml
@@ -22,6 +22,15 @@ fitbit:
     default_report:
       daily: false
       realtime: true
+      fields:
+        - activity_count
+        - distance
+        - calories
+        - duration
+        - fat_burn_minutes
+        - cardio_minutes
+        - peak_minutes
+        - out_of_zone_minutes
 
     activity_types:
       # Configuration specific to activity types.
@@ -44,6 +53,8 @@ fitbit:
         report:
           daily: true
           realtime: false
+          fields:
+             - distance
 
       - name: Spinning
         id: 55001

--- a/slackhealthbot/containers.py
+++ b/slackhealthbot/containers.py
@@ -11,6 +11,7 @@ class Container(containers.DeclarativeContainer):
             "slackhealthbot.domain.usecases.fitbit.usecase_process_daily_activity",
             "slackhealthbot.domain.usecases.fitbit.usecase_process_new_activity",
             "slackhealthbot.domain.usecases.slack.usecase_post_user_logged_out",
+            "slackhealthbot.domain.usecases.slack.usecase_post_activity",
             "slackhealthbot.oauth.fitbitconfig",
             "slackhealthbot.oauth.withingsconfig",
             "slackhealthbot.remoteservices.api.fitbit.activityapi",

--- a/slackhealthbot/containers.py
+++ b/slackhealthbot/containers.py
@@ -12,6 +12,7 @@ class Container(containers.DeclarativeContainer):
             "slackhealthbot.domain.usecases.fitbit.usecase_process_new_activity",
             "slackhealthbot.domain.usecases.slack.usecase_post_user_logged_out",
             "slackhealthbot.domain.usecases.slack.usecase_post_activity",
+            "slackhealthbot.domain.usecases.slack.usecase_post_daily_activity",
             "slackhealthbot.oauth.fitbitconfig",
             "slackhealthbot.oauth.withingsconfig",
             "slackhealthbot.remoteservices.api.fitbit.activityapi",

--- a/slackhealthbot/domain/usecases/slack/usecase_post_activity.py
+++ b/slackhealthbot/domain/usecases/slack/usecase_post_activity.py
@@ -123,18 +123,8 @@ def create_message(
             recent_top_value,
             record_history_days=record_history_days,
         )
-    activity_type_settings = next(
-        x
-        for x in settings.app_settings.fitbit.activities.activity_types
-        if x.name == activity_name
-    )
-    report_settings = (
-        activity_type_settings.report
-        if (
-            activity_type_settings.report
-            and activity_type_settings.report.fields is not None
-        )
-        else settings.app_settings.fitbit.activities.default_report
+    report_settings = settings.app_settings.fitbit.activities.get_report(
+        activity_type_id=activity_history.new_activity_data.type_id
     )
 
     message = f"""

--- a/slackhealthbot/domain/usecases/slack/usecase_post_activity.py
+++ b/slackhealthbot/domain/usecases/slack/usecase_post_activity.py
@@ -1,3 +1,7 @@
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends
+
+from slackhealthbot.containers import Container
 from slackhealthbot.domain.models.activity import ActivityHistory
 from slackhealthbot.domain.remoterepository.remoteslackrepository import (
     RemoteSlackRepository,
@@ -9,6 +13,7 @@ from slackhealthbot.domain.usecases.slack.usecase_activity_message_formatter imp
     get_activity_minutes_change_icon,
     get_ranking_text,
 )
+from slackhealthbot.settings import ReportField, Settings
 
 
 async def do(
@@ -24,11 +29,13 @@ async def do(
     await repo.post_message(message.strip())
 
 
+@inject
 def create_message(
     slack_alias: str,
     activity_name: str,
     activity_history: ActivityHistory,
     record_history_days: int,
+    settings: Settings = Depends(Provide[Container.settings]),
 ):
     activity = activity_history.new_activity_data
     zone_icons = {}
@@ -116,12 +123,33 @@ def create_message(
             recent_top_value,
             record_history_days=record_history_days,
         )
+    activity_type_settings = next(
+        x
+        for x in settings.app_settings.fitbit.activities.activity_types
+        if x.name == activity_name
+    )
+    report_settings = (
+        activity_type_settings.report
+        if (
+            activity_type_settings.report
+            and activity_type_settings.report.fields is not None
+        )
+        else settings.app_settings.fitbit.activities.default_report
+    )
+
     message = f"""
 New {activity_name} activity from <@{slack_alias}>:
-    • Duration: {activity.total_minutes} minutes {duration_icon} {duration_record_text}
-    • Calories: {activity.calories} {calories_icon} {calories_record_text}
 """
-    if activity.distance_km:
+
+    if ReportField.duration in report_settings.fields:
+        message += f"""    • Duration: {activity.total_minutes} minutes {duration_icon} {duration_record_text}
+"""
+
+    if ReportField.calories in report_settings.fields:
+        message += f"""    • Calories: {activity.calories} {calories_icon} {calories_record_text}
+"""
+
+    if ReportField.distance in report_settings.fields and activity.distance_km:
         message += f"""    • Distance: {activity.distance_km:.3f} km {distance_km_icon} {distance_km_record_text}
 """
     message += "\n".join(
@@ -131,6 +159,7 @@ New {activity_name} activity from <@{slack_alias}>:
             + zone_icons.get(zone_minutes.zone, "")
             + f" {zone_record_texts.get(zone_minutes.zone, '')}"
             for zone_minutes in activity.zone_minutes
+            if f"{zone_minutes.zone}_minutes" in report_settings.fields
         ]
     )
     return message

--- a/slackhealthbot/domain/usecases/slack/usecase_post_daily_activity.py
+++ b/slackhealthbot/domain/usecases/slack/usecase_post_daily_activity.py
@@ -155,18 +155,8 @@ def create_message(
         record_history_days=record_history_days,
     )
 
-    activity_type_settings = next(
-        x
-        for x in settings.app_settings.fitbit.activities.activity_types
-        if x.name == activity_name
-    )
-    report_settings = (
-        activity_type_settings.report
-        if (
-            activity_type_settings.report
-            and activity_type_settings.report.fields is not None
-        )
-        else settings.app_settings.fitbit.activities.default_report
+    report_settings = settings.app_settings.fitbit.activities.get_report(
+        activity_type_id=history.new_daily_activity_stats.type_id
     )
 
     message = f"""

--- a/slackhealthbot/main.py
+++ b/slackhealthbot/main.py
@@ -59,10 +59,13 @@ async def lifespan(_app: FastAPI):
             initial_delay_s=10,
         )
     daily_activity_task: Task | None = None
-    if settings.app_settings.fitbit_daily_activity_type_ids:
+    daily_activity_type_ids = (
+        settings.app_settings.fitbit.activities.daily_activity_type_ids
+    )
+    if daily_activity_type_ids:
         daily_activity_task = await post_daily_activities(
             local_fitbit_repo_factory=fitbit_repository_factory(),
-            activity_type_ids=set(settings.app_settings.fitbit_daily_activity_type_ids),
+            activity_type_ids=set(daily_activity_type_ids),
             slack_repo=get_slack_repository(),
             post_time=settings.app_settings.fitbit.activities.daily_report_time,
         )

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -2,6 +2,7 @@ import dataclasses
 import datetime as dt
 import enum
 import os
+from copy import deepcopy
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Optional
@@ -74,6 +75,32 @@ class Activities(BaseModel):
 
     def get_activity_type(self, id: int) -> ActivityType | None:
         return next((x for x in self.activity_types if x.id == id), None)
+
+    def get_report(self, activity_type_id: int) -> Report | None:
+        """
+        Get the report configuration for the given activity type.
+        If the activity type doesn't have an explicit report configuration,
+        fallback to the default report configuration.
+
+        If the activity type report configuration is missing some attributes,
+        fill them in with the default report configuration. This applies to the
+        following attributes:
+        - fields
+
+        :return None: If the activity type id is unknown
+        """
+        activity_type = self.get_activity_type(id=activity_type_id)
+        if not activity_type:
+            return None
+
+        if activity_type.report is None:
+            return self.default_report
+
+        report = deepcopy(activity_type.report)
+        if not report.fields:
+            report.fields = self.default_report.fields
+
+        return report
 
     @property
     def daily_activity_type_ids(self) -> list[int]:

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -75,6 +75,17 @@ class Activities(BaseModel):
     def get_activity_type(self, id: int) -> ActivityType | None:
         return next((x for x in self.activity_types if x.id == id), None)
 
+    @property
+    def daily_activity_type_ids(self) -> list[int]:
+        return [
+            x.id
+            for x in self.activity_types
+            if (
+                (x.report and x.report.daily)
+                or (x.report is None and self.default_report.daily)
+            )
+        ]
+
 
 class Fitbit(BaseModel):
     poll: Poll
@@ -142,17 +153,6 @@ class AppSettings(BaseSettings):
                 yaml_file=file.name,
             )
         return (env_settings, yaml_settings_source)
-
-    @property
-    def fitbit_daily_activity_type_ids(self) -> list[int]:
-        return [
-            x.id
-            for x in self.fitbit.activities.activity_types
-            if (
-                (x.report and x.report.daily)
-                or (x.report is None and self.fitbit.activities.default_report.daily)
-            )
-        ]
 
 
 class SecretSettings(BaseSettings):

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -1,8 +1,10 @@
 import dataclasses
 import datetime as dt
+import enum
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import Optional
 
 import yaml
 from pydantic import AnyHttpUrl, BaseModel, HttpUrl
@@ -37,9 +39,21 @@ class Poll(BaseModel):
     interval_seconds: int = 3600
 
 
+class ReportField(enum.StrEnum):
+    activity_count = enum.auto()
+    distance = enum.auto()
+    calories = enum.auto()
+    duration = enum.auto()
+    fat_burn_minutes = enum.auto()
+    cardio_minutes = enum.auto()
+    peak_minutes = enum.auto()
+    out_of_zone_minutes = enum.auto()
+
+
 class Report(BaseModel):
     daily: bool
     realtime: bool
+    fields: Optional[list[ReportField]] = None
 
 
 class ActivityType(BaseModel):
@@ -55,6 +69,7 @@ class Activities(BaseModel):
     default_report: Report = Report(
         daily=False,
         realtime=True,
+        fields=[x for x in ReportField],
     )
 
 

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -72,6 +72,9 @@ class Activities(BaseModel):
         fields=[x for x in ReportField],
     )
 
+    def get_activity_type(self, id: int) -> ActivityType | None:
+        return next((x for x in self.activity_types if x.id == id), None)
+
 
 class Fitbit(BaseModel):
     poll: Poll
@@ -141,17 +144,6 @@ class AppSettings(BaseSettings):
         return (env_settings, yaml_settings_source)
 
     @property
-    def fitbit_realtime_activity_type_ids(self) -> list[int]:
-        return [
-            x.id
-            for x in self.fitbit.activities.activity_types
-            if (
-                (x.report and x.report.realtime)
-                or (x.report is None and self.fitbit.activities.default_report.realtime)
-            )
-        ]
-
-    @property
     def fitbit_daily_activity_type_ids(self) -> list[int]:
         return [
             x.id
@@ -161,12 +153,6 @@ class AppSettings(BaseSettings):
                 or (x.report is None and self.fitbit.activities.default_report.daily)
             )
         ]
-
-    @property
-    def fitbit_activity_type_ids(self) -> list[int]:
-        return (
-            self.fitbit_realtime_activity_type_ids + self.fitbit_daily_activity_type_ids
-        )
 
 
 class SecretSettings(BaseSettings):

--- a/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
+++ b/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
@@ -1,5 +1,7 @@
+import dataclasses
 import datetime as dt
 import json
+from pathlib import Path
 
 import pytest
 from httpx import Response
@@ -13,10 +15,11 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
     LocalFitbitRepository,
 )
 from slackhealthbot.domain.usecases.fitbit import usecase_process_daily_activities
+from slackhealthbot.main import app
 from slackhealthbot.remoteservices.repositories.webhookslackrepository import (
     WebhookSlackRepository,
 )
-from slackhealthbot.settings import Settings
+from slackhealthbot.settings import AppSettings, SecretSettings, Settings
 from tests.testsupport.factories.factories import (
     FitbitActivityFactory,
     FitbitUserFactory,
@@ -25,19 +28,108 @@ from tests.testsupport.factories.factories import (
 from tests.testsupport.mock.builtins import freeze_time
 
 
+@dataclasses.dataclass
+class DailyActivityScenario:
+    id: str
+    custom_conf: str | None
+    expected_activity_message: str
+
+
+DAILY_ACTIVITY_SCENARIOS = [
+    DailyActivityScenario(
+        id="no custom conf",
+        custom_conf=None,
+        expected_activity_message="""New daily Treadmill activity from <@jdoe>:
+    • Activity count: 2
+    • Total duration: 15 minutes ↗️ New record (last 180 days)! 🏆
+    • Total calories: 250 ↗️ New record (last 180 days)! 🏆
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆
+    • Total cardio minutes: 12 ↗️ New record (last 180 days)! 🏆""",
+    ),
+    DailyActivityScenario(
+        id="distance only",
+        custom_conf="""
+fitbit:
+  activities:
+    activity_types:
+      - name: Treadmill
+        id: 90019
+        report:
+          daily: true
+          realtime: false
+          fields:
+            - distance
+""",
+        expected_activity_message="""New daily Treadmill activity from <@jdoe>:
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆""",
+    ),
+    DailyActivityScenario(
+        id="fat burn minutes without fat burn minutes",
+        custom_conf="""
+fitbit:
+  activities:
+    activity_types:
+      - name: Treadmill
+        id: 90019
+        report:
+          daily: true
+          realtime: false
+          fields:
+            - activity_count
+            - fat_burn_minutes
+""",
+        expected_activity_message="""New daily Treadmill activity from <@jdoe>:
+    • Activity count: 2""",
+    ),
+    DailyActivityScenario(
+        id="custom conf not overriding report values",
+        custom_conf="""
+fitbit:
+  activities:
+    activity_types:
+      - name: Treadmill
+        id: 90019
+""",
+        expected_activity_message="""New daily Treadmill activity from <@jdoe>:
+    • Activity count: 2
+    • Total duration: 15 minutes ↗️ New record (last 180 days)! 🏆
+    • Total calories: 250 ↗️ New record (last 180 days)! 🏆
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆
+    • Total cardio minutes: 12 ↗️ New record (last 180 days)! 🏆""",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ids=[x.id for x in DAILY_ACTIVITY_SCENARIOS],
+    argnames="scenario",
+    argvalues=DAILY_ACTIVITY_SCENARIOS,
+)
 @pytest.mark.asyncio
-async def test_process_daily_activities(
+async def test_process_daily_activities(  # noqa: PLR0913
     monkeypatch: pytest.MonkeyPatch,
     local_fitbit_repository: LocalFitbitRepository,
     respx_mock: MockRouter,
     fitbit_factories: tuple[UserFactory, FitbitUserFactory, FitbitActivityFactory],
+    scenario: DailyActivityScenario,
     settings: Settings,
+    tmp_path: Path,
 ):
+    if scenario.custom_conf:
+        custom_conf_path = tmp_path / "custom-conf.yaml"
+        with open(custom_conf_path, "w", encoding="utf-8") as custom_conf_file:
+            custom_conf_file.write(scenario.custom_conf)
+        with monkeypatch.context() as mp:
+            mp.setenv("SHB_CUSTOM_CONFIG_PATH", str(custom_conf_path))
+            settings = Settings(
+                app_settings=AppSettings(),
+                secret_settings=SecretSettings(),
+            )
     user_factory, _, fitbit_activity_factory = fitbit_factories
     old_date = dt.datetime(2023, 3, 4, 15, 44, 33)
     recent_date = dt.datetime(2024, 4, 2, 23, 44, 55)
     today = dt.datetime(2024, 8, 2, 10, 44, 55)
-    activity_type = 111
+    activity_type = 90019
     user: models.User = user_factory.create(slack_alias="jdoe")
 
     # All-time top stats in the old date:
@@ -141,22 +233,16 @@ async def test_process_daily_activities(
             dt_module_to_freeze=dt_to_freeze,
             frozen_datetime_args=(2024, 8, 2, 10, 44, 55),
         )
-        await usecase_process_daily_activities.do(
-            local_fitbit_repo=local_fitbit_repository,
-            type_ids={activity_type},
-            slack_repo=WebhookSlackRepository(),
-        )
+        with app.container.settings.override(settings):
+            await usecase_process_daily_activities.do(
+                local_fitbit_repo=local_fitbit_repository,
+                type_ids={activity_type},
+                slack_repo=WebhookSlackRepository(),
+            )
 
     assert slack_request.call_count == 1
     actual_activity_message = json.loads(slack_request.calls.last.request.content)[
         "text"
     ]
 
-    expected_activity_message = """New daily Unknown activity from <@jdoe>:
-    • Activity count: 2
-    • Total duration: 15 minutes ↗️ New record (last 180 days)! 🏆
-    • Total calories: 250 ↗️ New record (last 180 days)! 🏆
-    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆
-    • Total cardio minutes: 12 ↗️ New record (last 180 days)! 🏆"""
-
-    assert actual_activity_message == expected_activity_message
+    assert actual_activity_message == scenario.expected_activity_message

--- a/tests/tasks/test_post_daily_activities.py
+++ b/tests/tasks/test_post_daily_activities.py
@@ -116,7 +116,9 @@ async def test_post_daily_activities(
     )
     task: asyncio.Task = await post_daily_activities(
         local_fitbit_repo_factory=fitbit_repository_factory(mocked_async_session),
-        activity_type_ids=set(settings.app_settings.fitbit_daily_activity_type_ids),
+        activity_type_ids=set(
+            settings.app_settings.fitbit.activities.daily_activity_type_ids
+        ),
         slack_repo=WebhookSlackRepository(),
         post_time=settings.app_settings.fitbit.activities.daily_report_time,
     )

--- a/tests/testsupport/config/app-test.yaml
+++ b/tests/testsupport/config/app-test.yaml
@@ -34,3 +34,9 @@ fitbit:
         report:
           daily: false
           realtime: true
+
+      - name: Unknown
+        id: 0
+        report:
+          daily: true
+          realtime: true

--- a/tests/testsupport/config/app-test.yaml
+++ b/tests/testsupport/config/app-test.yaml
@@ -1,5 +1,4 @@
 # App config for test scenarios
-
 logging:
   sql_log_level: "DEBUG"
 
@@ -8,25 +7,30 @@ fitbit:
     activity_types:
       - name: Dancing
         id: 123
-        report_daily: true
-        report_realtime: true
+        report:
+          daily: true
+          realtime: true
 
       - name: Treadmill
         id: 90019
-        report_daily: true
-        report_realtime: false
+        report:
+          daily: true
+          realtime: false
 
       - name: Spinning
         id: 55001
-        report_daily: false
-        report_realtime: true
+        report:
+          daily: false
+          realtime: true
 
       - name: Walking
         id: 55001
-        report_daily: false
-        report_realtime: true
+        report:
+          daily: false
+          realtime: true
 
       - name: Walk
         id: 90013
-        report_daily: false
-        report_realtime: true
+        report:
+          daily: false
+          realtime: true

--- a/tests/testsupport/testdata/fitbit_scenarios.py
+++ b/tests/testsupport/testdata/fitbit_scenarios.py
@@ -3,7 +3,7 @@ import datetime
 from typing import Any
 
 from slackhealthbot.domain.models.sleep import SleepData
-from slackhealthbot.settings import ActivityType
+from slackhealthbot.settings import ActivityType, Report
 
 
 @dataclasses.dataclass
@@ -616,8 +616,10 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
                 ActivityType(
                     name="Spinning",
                     id=55001,
-                    report_realtime=False,
-                    report_daily=True,
+                    report=Report(
+                        realtime=False,
+                        daily=True,
+                    ),
                 )
             ],
         },


### PR DESCRIPTION
Issue #83 

Adapt the reporting settings in the app yaml config.

Before:
```yaml
        report_daily: true
        report_realtime: false
```
Now:
```yaml
        report:
          daily: true
          realtime: false
          fields:
            - distance
            - calories
            - # ... etc
```

Add a `default_report` block as a child of `activities`.

Add a `report` block as a child of an item of `activity_types`.

The config for an activity type can override the settings in the `default_report` block.


Only the fields listed in the `fields` attribute will be included in the message posted to Slack.