### PR TITLE
Fix a config bug with activity_type item not containing a `report` block.

### DIFF
--- a/slackhealthbot/domain/usecases/fitbit/usecase_process_new_activity.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_process_new_activity.py
@@ -21,7 +21,7 @@ from slackhealthbot.domain.remoterepository.remoteslackrepository import (
 )
 from slackhealthbot.domain.usecases.fitbit import usecase_get_last_activity
 from slackhealthbot.domain.usecases.slack import usecase_post_activity
-from slackhealthbot.settings import ActivityType, Settings
+from slackhealthbot.settings import Settings
 
 
 @inject
@@ -74,12 +74,10 @@ async def do(  # noqa: PLR0913 deal with this later
         activity=new_activity_data,
     )
 
-    activity_type: ActivityType = (
-        settings.app_settings.fitbit.activities.get_activity_type(
-            id=new_activity_data.type_id
-        )
+    report = settings.app_settings.fitbit.activities.get_report(
+        activity_type_id=new_activity_data.type_id
     )
-    if activity_type is None or not activity_type.report.realtime:
+    if report is None or not report.realtime:
         # This activity isn't to be posted in realtime to slack.
         # We're done for now.
         return

--- a/tests/testsupport/testdata/fitbit_scenarios.py
+++ b/tests/testsupport/testdata/fitbit_scenarios.py
@@ -624,6 +624,62 @@ activity_scenarios: dict[str, FitbitActivityScenario] = {
             ],
         },
     ),
+    "Activity type without report block": FitbitActivityScenario(
+        input_initial_activity_data={
+            "log_id": 1234,
+            "total_minutes": 30,
+            "calories": 10,
+            "fat_burn_minutes": 7,
+            "cardio_minutes": 13,
+            "created_at": datetime.datetime(1999, 12, 31, 0, 0, 0),
+            "updated_at": datetime.datetime(1999, 12, 31, 0, 0, 0),
+        },
+        input_mock_fitbit_response={
+            "activities": [
+                {
+                    "activeZoneMinutes": {
+                        "minutesInHeartRateZones": [
+                            {
+                                "minutes": 8,
+                                "type": "FAT_BURN",
+                            },
+                            {
+                                "minutes": 9,
+                                "type": "CARDIO",
+                            },
+                            {
+                                "minutes": 0,
+                                "type": "OUT_OF_ZONE",
+                            },
+                            {
+                                "minutes": 0,
+                                "type": "PEAK",
+                            },
+                        ]
+                    },
+                    "activityName": "Spinning",
+                    "activityTypeId": 55001,
+                    "logId": 1235,
+                    "calories": 76,
+                    "duration": 665000,
+                },
+            ]
+        },
+        expected_new_last_activity_log_id=1235,
+        expected_new_activity_created=True,
+        expected_message_pattern=(
+            "New Spinning activity.*⬇️ New record.*⬆️ New all-time record.*Fat burn.*8.*➡.*New all-time "
+            "record.*Cardio.*9.*↘️ New record"
+        ),
+        settings_override={
+            "app_settings.fitbit.activities.activity_types": [
+                ActivityType(
+                    name="Spinning",
+                    id=55001,
+                )
+            ],
+        },
+    ),
     "Invalid json response": FitbitActivityScenario(
         input_initial_activity_data={
             "log_id": 1234,


### PR DESCRIPTION
* Create a test to reproduce the bug.
* Fix the bug by falling back to the default report configuration.