### PR TITLE
Add daily goals.

### DIFF
--- a/config/app-default.yaml
+++ b/config/app-default.yaml
@@ -31,6 +31,8 @@ fitbit:
         - cardio_minutes
         - peak_minutes
         - out_of_zone_minutes
+      daily_goals:
+        # distance_km: 1.0
 
     activity_types:
       # Configuration specific to activity types.
@@ -55,6 +57,8 @@ fitbit:
           realtime: false
           fields:
              - distance
+          daily_goals:
+            distance_km: 20.0
 
       - name: Spinning
         id: 55001

--- a/slackhealthbot/domain/usecases/slack/usecase_post_daily_activity.py
+++ b/slackhealthbot/domain/usecases/slack/usecase_post_daily_activity.py
@@ -178,7 +178,15 @@ New daily {activity_name} activity from <@{slack_alias}>:
         ReportField.distance in report_settings.fields
         and history.new_daily_activity_stats.sum_distance_km
     ):
-        message += f"""    • Distance: {history.new_daily_activity_stats.sum_distance_km:.3f} km {distance_km_icon} {distance_km_record_text}
+        message += f"    • Distance: {history.new_daily_activity_stats.sum_distance_km:.3f} km {distance_km_icon} {distance_km_record_text}"
+        if (
+            report_settings.daily_goals
+            and report_settings.daily_goals.distance_km
+            and history.new_daily_activity_stats.sum_distance_km
+            > report_settings.daily_goals.distance_km
+        ):
+            message += " Goal reached! 👍"
+        message += """
 """
     if (
         ReportField.fat_burn_minutes in report_settings.fields

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -51,10 +51,15 @@ class ReportField(enum.StrEnum):
     out_of_zone_minutes = enum.auto()
 
 
+class Goals(BaseModel):
+    distance_km: float | None = None
+
+
 class Report(BaseModel):
     daily: bool
     realtime: bool
     fields: Optional[list[ReportField]] = None
+    daily_goals: Goals | None = None
 
 
 class ActivityType(BaseModel):

--- a/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
+++ b/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
@@ -59,9 +59,11 @@ fitbit:
           realtime: false
           fields:
             - distance
+          daily_goals:
+            distance_km: 0.01
 """,
         expected_activity_message="""New daily Treadmill activity from <@jdoe>:
-    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆""",
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 Goal reached! 👍""",
     ),
     DailyActivityScenario(
         id="fat burn minutes without fat burn minutes",


### PR DESCRIPTION
Add an optional `daily_goals` block for the `report` configuration of an activity type.

Currently this block has only one supported attribute: `distance_km`, whose value is a float.

When posting a daily report to slack, indicate if the day's distance total has exceeded the daily `distance_km` goal for that activity type.