### PR TITLE
Implement streak reporting

### DIFF
--- a/scripts/codecheck.sh
+++ b/scripts/codecheck.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 error=0
 for project in slackhealthbot alembic tests
 do

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,10 +1,12 @@
+#!/usr/bin/env bash
 rm -rf reports
-LOGGING__SQL_LOG_LEVEL=DEBUG python -m pytest \
+python -m pytest \
   --numprocesses=auto \
   --cov=slackhealthbot \
   --cov-report=xml \
   --cov-report=html \
   --junitxml="reports/junit.xml" \
-  tests
+  tests \
+  $*
 mkdir -p reports
 mv coverage.xml htmlcov reports/.

--- a/slackhealthbot/data/database/models.py
+++ b/slackhealthbot/data/database/models.py
@@ -1,3 +1,4 @@
+from datetime import date as dt_date
 from datetime import datetime
 from typing import Optional
 
@@ -84,7 +85,7 @@ class FitbitDailyActivity(Base):
     )
     fitbit_user: Mapped["FitbitUser"] = relationship(lazy="joined", join_depth=2)
     type_id: Mapped[int] = mapped_column(primary_key=True)
-    date: Mapped[datetime] = mapped_column(primary_key=True)
+    date: Mapped[dt_date] = mapped_column(primary_key=True)
     count_activities: Mapped[int] = mapped_column()
     sum_calories: Mapped[int] = mapped_column()
     sum_distance_km: Mapped[float] = mapped_column()

--- a/slackhealthbot/data/repositories/sqlalchemyfitbitrepository.py
+++ b/slackhealthbot/data/repositories/sqlalchemyfitbitrepository.py
@@ -342,6 +342,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         if not daily_activity:
             return None
         return DailyActivityStats(
+            date=daily_activity.date,
             fitbit_userid=daily_activity.fitbit_user.oauth_userid,
             slack_alias=daily_activity.fitbit_user.user.slack_alias,
             type_id=daily_activity.type_id,
@@ -374,6 +375,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         )
         return [
             DailyActivityStats(
+                date=daily_activity.date,
                 fitbit_userid=daily_activity.fitbit_user.oauth_userid,
                 slack_alias=daily_activity.fitbit_user.user.slack_alias,
                 type_id=daily_activity.type_id,

--- a/slackhealthbot/domain/localrepository/localfitbitrepository.py
+++ b/slackhealthbot/domain/localrepository/localfitbitrepository.py
@@ -128,6 +128,21 @@ class LocalFitbitRepository(ABC):
         pass
 
     @abstractmethod
+    async def get_oldest_daily_activity_by_user_and_activity_type_in_streak(
+        self,
+        fitbit_userid: str,
+        type_id: int,
+        *,
+        before: datetime.date | None = None,
+        min_distance_km: float | None = None,
+    ) -> DailyActivityStats | None:
+        """
+        Get the oldest activity for the given user and activity type, in the current streak.
+        Returns None if the activity for the given date does not meet the given goal.
+        """
+        pass
+
+    @abstractmethod
     async def get_daily_activities_by_type(
         self,
         type_ids: set[int],

--- a/slackhealthbot/domain/models/activity.py
+++ b/slackhealthbot/domain/models/activity.py
@@ -76,3 +76,4 @@ class DailyActivityHistory:
     new_daily_activity_stats: DailyActivityStats | None
     all_time_top_daily_activity_stats: TopDailyActivityStats
     recent_top_daily_activity_stats: TopDailyActivityStats
+    streak_distance_km_days: int | None

--- a/slackhealthbot/domain/models/activity.py
+++ b/slackhealthbot/domain/models/activity.py
@@ -1,4 +1,5 @@
 import dataclasses
+import datetime as dt
 from enum import StrEnum, auto
 
 
@@ -43,6 +44,7 @@ class ActivityHistory:
 
 @dataclasses.dataclass
 class DailyActivityStats:
+    date: dt.date
     fitbit_userid: int
     slack_alias: str
     type_id: int

--- a/slackhealthbot/domain/usecases/fitbit/usecase_process_daily_activity.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_process_daily_activity.py
@@ -36,6 +36,26 @@ async def do(
 ):
     now = dt.datetime.now(dt.timezone.utc)
     fitbit_userid = daily_activity.fitbit_userid
+    report_settings = settings.app_settings.fitbit.activities.get_report(
+        activity_type_id=daily_activity.type_id
+    )
+    oldest_daily_activity_stats_in_streak: DailyActivityStats = (
+        await local_fitbit_repo.get_oldest_daily_activity_by_user_and_activity_type_in_streak(
+            fitbit_userid=fitbit_userid,
+            type_id=daily_activity.type_id,
+            before=now,
+            min_distance_km=(
+                report_settings.daily_goals.distance_km
+                if report_settings.daily_goals
+                else None
+            ),
+        )
+    )
+    streak_distance_km_days = (
+        (now.date() - oldest_daily_activity_stats_in_streak.date).days + 1
+        if oldest_daily_activity_stats_in_streak
+        else None
+    )
     user_identity: UserIdentity = (
         await local_fitbit_repo.get_user_identity_by_fitbit_userid(
             fitbit_userid=fitbit_userid
@@ -68,6 +88,7 @@ async def do(
         new_daily_activity_stats=daily_activity,
         all_time_top_daily_activity_stats=all_time_top_daily_activity_stats,
         recent_top_daily_activity_stats=recent_top_daily_activity_stats,
+        streak_distance_km_days=streak_distance_km_days,
     )
 
     await usecase_post_daily_activity.do(

--- a/slackhealthbot/domain/usecases/slack/usecase_post_daily_activity.py
+++ b/slackhealthbot/domain/usecases/slack/usecase_post_daily_activity.py
@@ -186,6 +186,8 @@ New daily {activity_name} activity from <@{slack_alias}>:
             > report_settings.daily_goals.distance_km
         ):
             message += " Goal reached! 👍"
+        if history.streak_distance_km_days:
+            message += f" {history.streak_distance_km_days} day streak! 👏"
         message += """
 """
     if (

--- a/tests/data/repositories/test_fitbitrepository.py
+++ b/tests/data/repositories/test_fitbitrepository.py
@@ -267,6 +267,7 @@ async def test_daily_activities_one_entry(
     )
     expected_daily_activity_stats = [
         DailyActivityStats(
+            date=datetime.date(2024, 1, 2),
             fitbit_userid=user.fitbit.oauth_userid,
             slack_alias="jondoe",
             type_id=1234,

--- a/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
+++ b/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
@@ -43,11 +43,11 @@ DAILY_ACTIVITY_SCENARIOS = [
     • Activity count: 2
     • Total duration: 15 minutes ↗️ New record (last 180 days)! 🏆
     • Total calories: 250 ↗️ New record (last 180 days)! 🏆
-    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 1 day streak! 👏
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 2 day streak! 👏
     • Total cardio minutes: 12 ↗️ New record (last 180 days)! 🏆""",
     ),
     DailyActivityScenario(
-        id="distance only, met goal",
+        id="distance only, met goal yesterday and today",
         custom_conf="""
 fitbit:
   activities:
@@ -61,6 +61,25 @@ fitbit:
             - distance
           daily_goals:
             distance_km: 0.01
+""",
+        expected_activity_message="""New daily Treadmill activity from <@jdoe>:
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 Goal reached! 👍 2 day streak! 👏""",
+    ),
+    DailyActivityScenario(
+        id="distance only, met goal today (not yesterday)",
+        custom_conf="""
+fitbit:
+  activities:
+    activity_types:
+      - name: Treadmill
+        id: 90019
+        report:
+          daily: true
+          realtime: false
+          fields:
+            - distance
+          daily_goals:
+            distance_km: 12
 """,
         expected_activity_message="""New daily Treadmill activity from <@jdoe>:
     • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 Goal reached! 👍 1 day streak! 👏""",
@@ -115,7 +134,7 @@ fitbit:
     • Activity count: 2
     • Total duration: 15 minutes ↗️ New record (last 180 days)! 🏆
     • Total calories: 250 ↗️ New record (last 180 days)! 🏆
-    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 1 day streak! 👏
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 2 day streak! 👏
     • Total cardio minutes: 12 ↗️ New record (last 180 days)! 🏆""",
     ),
 ]
@@ -148,8 +167,8 @@ async def test_process_daily_activities(  # noqa: PLR0913
             )
     user_factory, _, fitbit_activity_factory = fitbit_factories
     old_date = dt.datetime(2023, 3, 4, 15, 44, 33)
-    recent_date = dt.datetime(2024, 4, 2, 23, 44, 55)
     today = dt.datetime(2024, 8, 2, 10, 44, 55)
+    yesterday = dt.datetime(2024, 8, 1, 10, 40, 3)
     activity_type = 90019
     user: models.User = user_factory.create(slack_alias="jdoe")
 
@@ -183,7 +202,7 @@ async def test_process_daily_activities(  # noqa: PLR0913
         updated_at=old_date,
     )
 
-    # Top stats in the recent date.
+    # Top stats for yesterday.
     # - 200 calories
     # - 10km
     # - 11 minutes total
@@ -198,7 +217,7 @@ async def test_process_daily_activities(  # noqa: PLR0913
         fat_burn_minutes=None,
         peak_minutes=None,
         out_of_zone_minutes=None,
-        updated_at=recent_date,
+        updated_at=yesterday,
     )
     fitbit_activity_factory.create(
         fitbit_user_id=user.fitbit.id,
@@ -210,7 +229,7 @@ async def test_process_daily_activities(  # noqa: PLR0913
         fat_burn_minutes=None,
         peak_minutes=None,
         out_of_zone_minutes=None,
-        updated_at=recent_date,
+        updated_at=yesterday,
     )
 
     # Stats for today

--- a/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
+++ b/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
@@ -43,11 +43,11 @@ DAILY_ACTIVITY_SCENARIOS = [
     • Activity count: 2
     • Total duration: 15 minutes ↗️ New record (last 180 days)! 🏆
     • Total calories: 250 ↗️ New record (last 180 days)! 🏆
-    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 1 day streak! 👏
     • Total cardio minutes: 12 ↗️ New record (last 180 days)! 🏆""",
     ),
     DailyActivityScenario(
-        id="distance only",
+        id="distance only, met goal",
         custom_conf="""
 fitbit:
   activities:
@@ -63,7 +63,26 @@ fitbit:
             distance_km: 0.01
 """,
         expected_activity_message="""New daily Treadmill activity from <@jdoe>:
-    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 Goal reached! 👍""",
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 Goal reached! 👍 1 day streak! 👏""",
+    ),
+    DailyActivityScenario(
+        id="distance only, didn't meet goal",
+        custom_conf="""
+fitbit:
+  activities:
+    activity_types:
+      - name: Treadmill
+        id: 90019
+        report:
+          daily: true
+          realtime: false
+          fields:
+            - distance
+          daily_goals:
+            distance_km: 100
+""",
+        expected_activity_message="""New daily Treadmill activity from <@jdoe>:
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆""",
     ),
     DailyActivityScenario(
         id="fat burn minutes without fat burn minutes",
@@ -96,7 +115,7 @@ fitbit:
     • Activity count: 2
     • Total duration: 15 minutes ↗️ New record (last 180 days)! 🏆
     • Total calories: 250 ↗️ New record (last 180 days)! 🏆
-    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆
+    • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆 1 day streak! 👏
     • Total cardio minutes: 12 ↗️ New record (last 180 days)! 🏆""",
     ),
 ]

--- a/tests/tasks/test_post_daily_activities.py
+++ b/tests/tasks/test_post_daily_activities.py
@@ -139,7 +139,7 @@ async def test_post_daily_activities(
     • Activity count: 1
     • Total duration: 116 minutes ↗️ New record (last 180 days)! 🏆
     • Total calories: 805 ➡️ 
-    • Distance: 9.500 km ➡️ 
+    • Distance: 9.500 km ➡️  1 day streak! 👏
     • Total fat burn minutes: 41 ➡️ 
     • Total cardio minutes: 35 ↗️ 
     • Total peak minutes: 1  New all-time record! 🏆"""


### PR DESCRIPTION
### Preparation
* CI script improvements:
   * Make scripts executable.
   * Enable logging of SQL queries when running tests.
   * Pass `run_tests.sh` arguments to pytest.     
   To see SQL queries when running tests: `./scripts/run_tests -sv`
* Correct the type hint for the `date` field in the `FitbitDailyActivity` view.

### New feature
Implement streak reporting.

For this iteration, streaks are only reported for distance.

If a goal is set for distance, the streak is the last X days, including today, where the distance goal was met.
 
If no goal was set for distance, the streak is the last X days, including today, where there was activity.
 
The streak information is included as part of the "distance" item in the Slack message.


This is an MVP. The code will surely need to be refactored, if/when we decide to calculate streaks wrt goals differently (ie, support streaks for duration, calories, or other metrics).
