### PR TITLE
Fix streak calculation when we didn't meet the goal today.

### DIFF
--- a/slackhealthbot/containers.py
+++ b/slackhealthbot/containers.py
@@ -10,6 +10,7 @@ class Container(containers.DeclarativeContainer):
         modules=[
             "slackhealthbot.domain.usecases.fitbit.usecase_process_daily_activity",
             "slackhealthbot.domain.usecases.fitbit.usecase_process_new_activity",
+            "slackhealthbot.domain.usecases.fitbit.usecase_calculate_streak",
             "slackhealthbot.domain.usecases.slack.usecase_post_user_logged_out",
             "slackhealthbot.domain.usecases.slack.usecase_post_activity",
             "slackhealthbot.domain.usecases.slack.usecase_post_daily_activity",

--- a/slackhealthbot/domain/usecases/fitbit/usecase_calculate_streak.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_calculate_streak.py
@@ -1,0 +1,58 @@
+import datetime as dt
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends
+
+from slackhealthbot.containers import Container
+from slackhealthbot.domain.localrepository.localfitbitrepository import (
+    LocalFitbitRepository,
+)
+from slackhealthbot.domain.models.activity import (
+    DailyActivityStats,
+)
+from slackhealthbot.settings import Settings
+
+
+@inject
+async def do(
+    local_fitbit_repo: LocalFitbitRepository,
+    daily_activity: DailyActivityStats,
+    end_date: dt.date,
+    settings: Settings = Depends(Provide[Container.settings]),
+) -> int | None:
+    """
+    If we have a goal and we met it at the given date, return the number of consecutive
+    days in which the goal was met before, and including this date.
+
+    If we have no goal, return the number of consecutive days, before and including the
+    given date, where we had an activity.
+
+    If we have a goal and we didn't meet it at the given date, there's no streak: return None.
+    """
+    fitbit_userid = daily_activity.fitbit_userid
+    report_settings = settings.app_settings.fitbit.activities.get_report(
+        activity_type_id=daily_activity.type_id
+    )
+    goal_distance_km = (
+        report_settings.daily_goals.distance_km if report_settings.daily_goals else None
+    )
+    # If we have a goal and we didn't meet it at the given date, there's no streak: return None.
+    if goal_distance_km and daily_activity.sum_distance_km < goal_distance_km:
+        return None
+
+    # Get the oldest day in the current streak, if it exists.
+    oldest_daily_activity_stats_in_streak: DailyActivityStats = (
+        await local_fitbit_repo.get_oldest_daily_activity_by_user_and_activity_type_in_streak(
+            fitbit_userid=fitbit_userid,
+            type_id=daily_activity.type_id,
+            before=end_date,
+            min_distance_km=goal_distance_km,
+        )
+    )
+
+    # Return the number of days since the first day in the streak, including the given end_date.
+    return (
+        (end_date - oldest_daily_activity_stats_in_streak.date).days + 1
+        if oldest_daily_activity_stats_in_streak
+        else None
+    )

--- a/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
+++ b/tests/domain/usecases/fitbit/test_usecase_process_daily_activities.py
@@ -98,7 +98,7 @@ fitbit:
           fields:
             - distance
           daily_goals:
-            distance_km: 100
+            distance_km: 18
 """,
         expected_activity_message="""New daily Treadmill activity from <@jdoe>:
     • Distance: 15.000 km ⬆️ New record (last 180 days)! 🏆""",


### PR DESCRIPTION
* Adjust a unit test to reproduce the bug.
* Fix the bug:
  - First, move the streak calculation to its own use case, as it's getting to be a bit big.
  - Then: if we didn't meet the goal today, don't even bother trying to calculate the streak. We know it's 0.