### PR TITLE
Configure http timeouts and retries globally on the httpx clients.

### DIFF
--- a/config/app-default.yaml
+++ b/config/app-default.yaml
@@ -1,5 +1,6 @@
 # Configuration of the slack-health-bot application
 server_url: "http://localhost:8000/" # The url to access the slack-health-bot server for login.
+request_timeout_s: 30.0 # The timeout in seconds for http requests made to withings, fitbit, and slack.
 database_path: "/tmp/data/slackhealthbot.db" # The location to the database file.
 logging:
   sql_log_level: "WARNING"

--- a/config/app-default.yaml
+++ b/config/app-default.yaml
@@ -1,6 +1,7 @@
 # Configuration of the slack-health-bot application
 server_url: "http://localhost:8000/" # The url to access the slack-health-bot server for login.
 request_timeout_s: 30.0 # The timeout in seconds for http requests made to withings, fitbit, and slack.
+request_retries: 2 # The number of times to retry http requests made to withings, fitbit, and slack.
 database_path: "/tmp/data/slackhealthbot.db" # The location to the database file.
 logging:
   sql_log_level: "WARNING"

--- a/slackhealthbot/oauth/fitbitconfig.py
+++ b/slackhealthbot/oauth/fitbitconfig.py
@@ -52,5 +52,6 @@ def configure(
         client_kwargs={
             "code_challenge_method": "S256",
             "is_auth_failure": is_auth_failure,
+            "timeout": settings.app_settings.request_timeout_s,
         },
     )

--- a/slackhealthbot/oauth/fitbitconfig.py
+++ b/slackhealthbot/oauth/fitbitconfig.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Callable, Coroutine
 
+import httpx
 from authlib.integrations.httpx_client.oauth2_client import AsyncOAuth2Client
 from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, status
@@ -53,5 +54,8 @@ def configure(
             "code_challenge_method": "S256",
             "is_auth_failure": is_auth_failure,
             "timeout": settings.app_settings.request_timeout_s,
+            "transport": httpx.AsyncHTTPTransport(
+                retries=settings.app_settings.request_retries
+            ),
         },
     )

--- a/slackhealthbot/oauth/requests.py
+++ b/slackhealthbot/oauth/requests.py
@@ -31,7 +31,6 @@ async def get(
         url,
         params=params,
         token=asdict(token),
-        timeout=30.0,
     )
     if client.client_kwargs["is_auth_failure"](response):
         raise UserLoggedOutException
@@ -54,7 +53,6 @@ async def post(
         url,
         data=data,
         token=asdict(token),
-        timeout=30.0,
     )
     if client.client_kwargs["is_auth_failure"](response):
         raise UserLoggedOutException

--- a/slackhealthbot/oauth/withingsconfig.py
+++ b/slackhealthbot/oauth/withingsconfig.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Callable, Coroutine
 
+import httpx
 from authlib.common.urls import add_params_to_qs
 from authlib.integrations.httpx_client.oauth2_client import AsyncOAuth2Client
 from dependency_injector.wiring import Provide, inject
@@ -71,5 +72,8 @@ def configure(
         client_kwargs={
             "is_auth_failure": is_auth_failure,
             "timeout": settings.app_settings.request_timeout_s,
+            "transport": httpx.AsyncHTTPTransport(
+                retries=settings.app_settings.request_retries
+            ),
         },
     )

--- a/slackhealthbot/oauth/withingsconfig.py
+++ b/slackhealthbot/oauth/withingsconfig.py
@@ -70,5 +70,6 @@ def configure(
         token_endpoint_auth_method="client_secret_post",
         client_kwargs={
             "is_auth_failure": is_auth_failure,
+            "timeout": settings.app_settings.request_timeout_s,
         },
     )

--- a/slackhealthbot/remoteservices/api/slack/messageapi.py
+++ b/slackhealthbot/remoteservices/api/slack/messageapi.py
@@ -11,11 +11,15 @@ async def post_message(
     message: str,
     settings: Settings = Depends(Provide[Container.settings]),
 ):
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(
+        timeout=settings.app_settings.request_timeout_s,
+        transport=httpx.AsyncHTTPTransport(
+            retries=settings.app_settings.request_retries
+        ),
+    ) as client:
         await client.post(
             url=str(settings.secret_settings.slack_webhook_url),
             json={
                 "text": message,
             },
-            timeout=30.0,
         )

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -139,6 +139,7 @@ class Logging(BaseModel):
 class AppSettings(BaseSettings):
     server_url: AnyHttpUrl
     request_timeout_s: float
+    request_retries: int
     database_path: Path = "/tmp/data/slackhealthbot.db"
     logging: Logging
     withings: Withings

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -138,6 +138,7 @@ class Logging(BaseModel):
 
 class AppSettings(BaseSettings):
     server_url: AnyHttpUrl
+    request_timeout_s: float
     database_path: Path = "/tmp/data/slackhealthbot.db"
     logging: Logging
     withings: Withings


### PR DESCRIPTION
This means the client will also have the configured timeouts and retries for:

* oauth requests (ex: token refresh)
* retrieving fitness data from withings and fitbit
* posting messages to slack 