### PR TITLE
Update streak logic

### DIFF
--- a/config/app-default.yaml
+++ b/config/app-default.yaml
@@ -35,6 +35,19 @@ fitbit:
         - out_of_zone_minutes
       daily_goals:
         # distance_km: 1.0
+      # Possible options for streak_mode (defaut is strict):
+      #
+      # - strict: the streak is the number of consecutive days, up to and including today,
+      #   for which an activity was logged and any daily_goals were met.
+      #   Days with no logged activity break the streak.
+      #
+      # - lax: the streak is the number of possibily non-consecutive days, up to
+      #   and including today, for which an activity was logged and any daily_goals were
+      #   met. The streak starts after the last date for which an activity was logged
+      #   which didn't meet the daily_goals, or from the beginning of the history if no
+      #   days were logged which didn't meet the daily_goals.
+      #   Days with no logged activity are ignored.
+      streak_mode: strict
 
     activity_types:
       # Configuration specific to activity types.

--- a/slackhealthbot/data/repositories/sqlalchemyfitbitrepository.py
+++ b/slackhealthbot/data/repositories/sqlalchemyfitbitrepository.py
@@ -364,6 +364,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         *,
         before: datetime.date | None = None,
         min_distance_km: float | None = None,
+        days_without_activies_break_streak=True,
     ) -> int:
         activity_date = before if before else datetime.date.today()
         before_date_daily_activity: models.FitbitDailyActivity = (
@@ -389,11 +390,16 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         ):
             return 0
 
-        return await self._calculate_streak_strict_mode(
-            fitbit_userid=fitbit_userid,
-            type_id=type_id,
-            up_to_date=activity_date,
-            min_distance_km=min_distance_km,
+        if days_without_activies_break_streak:
+            return await self._calculate_streak_strict_mode(
+                fitbit_userid=fitbit_userid,
+                type_id=type_id,
+                up_to_date=activity_date,
+                min_distance_km=min_distance_km,
+            )
+
+        raise NotImplementedError(
+            "days_without_activies_break_streak=False not yet supported"
         )
 
     async def _calculate_streak_strict_mode(

--- a/slackhealthbot/domain/localrepository/localfitbitrepository.py
+++ b/slackhealthbot/domain/localrepository/localfitbitrepository.py
@@ -128,17 +128,27 @@ class LocalFitbitRepository(ABC):
         pass
 
     @abstractmethod
-    async def get_oldest_daily_activity_by_user_and_activity_type_in_streak(
+    async def get_daily_activity_streak_days_count_for_user_and_activity_type(
         self,
         fitbit_userid: str,
         type_id: int,
         *,
         before: datetime.date | None = None,
         min_distance_km: float | None = None,
-    ) -> DailyActivityStats | None:
+    ) -> int:
         """
-        Get the oldest activity for the given user and activity type, in the current streak.
-        Returns None if the activity for the given date does not meet the given goal.
+        The streak is the number of consecutive days, up until and including the given "before" date
+        for which activity meeting a critera was logged.
+
+        If before is not provided, before is set to the current date.
+
+        If min_distance_km is provided, only days where the logged distance is at least
+        this value count toward the streak.
+
+        :return: 0 if no activity is logged for the "before" date, or if activity was logged
+            for the "before" date but does not meet the given min_distance_km.
+
+        :return: the number of days in the streak otherwise.
         """
         pass
 

--- a/slackhealthbot/domain/localrepository/localfitbitrepository.py
+++ b/slackhealthbot/domain/localrepository/localfitbitrepository.py
@@ -135,15 +135,25 @@ class LocalFitbitRepository(ABC):
         *,
         before: datetime.date | None = None,
         min_distance_km: float | None = None,
+        days_without_activies_break_streak=True,
     ) -> int:
         """
-        The streak is the number of consecutive days, up until and including the given "before" date
+        The streak is the number of days, up until and including the given "before" date
         for which activity meeting a critera was logged.
+
+        Currently the only supported criteria is min_distance_km.
 
         If before is not provided, before is set to the current date.
 
         If min_distance_km is provided, only days where the logged distance is at least
         this value count toward the streak.
+
+        :param days_without_activities_break_streak: If True, then days without the given
+            type of activity logged for the user will break the streak.
+
+            If False, then these days don't count toward the number of days in the streak
+            count, but they don't break the streak. Only days with activity logs but not
+            matching the criteria will break the streak.
 
         :return: 0 if no activity is logged for the "before" date, or if activity was logged
             for the "before" date but does not meet the given min_distance_km.

--- a/slackhealthbot/domain/usecases/fitbit/usecase_calculate_streak.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_calculate_streak.py
@@ -40,19 +40,10 @@ async def do(
     if goal_distance_km and daily_activity.sum_distance_km < goal_distance_km:
         return None
 
-    # Get the oldest day in the current streak, if it exists.
-    oldest_daily_activity_stats_in_streak: DailyActivityStats = (
-        await local_fitbit_repo.get_oldest_daily_activity_by_user_and_activity_type_in_streak(
-            fitbit_userid=fitbit_userid,
-            type_id=daily_activity.type_id,
-            before=end_date,
-            min_distance_km=goal_distance_km,
-        )
-    )
-
     # Return the number of days since the first day in the streak, including the given end_date.
-    return (
-        (end_date - oldest_daily_activity_stats_in_streak.date).days + 1
-        if oldest_daily_activity_stats_in_streak
-        else None
+    return await local_fitbit_repo.get_daily_activity_streak_days_count_for_user_and_activity_type(
+        fitbit_userid=fitbit_userid,
+        type_id=daily_activity.type_id,
+        before=end_date,
+        min_distance_km=goal_distance_km,
     )

--- a/slackhealthbot/domain/usecases/fitbit/usecase_calculate_streak.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_calculate_streak.py
@@ -10,7 +10,7 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
 from slackhealthbot.domain.models.activity import (
     DailyActivityStats,
 )
-from slackhealthbot.settings import Settings
+from slackhealthbot.settings import Settings, StreakMode
 
 
 @inject
@@ -46,4 +46,6 @@ async def do(
         type_id=daily_activity.type_id,
         before=end_date,
         min_distance_km=goal_distance_km,
+        days_without_activies_break_streak=report_settings.streak_mode
+        == StreakMode.strict,
     )

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -55,11 +55,17 @@ class Goals(BaseModel):
     distance_km: float | None = None
 
 
+class StreakMode(enum.StrEnum):
+    strict = enum.auto()
+    lax = enum.auto()
+
+
 class Report(BaseModel):
     daily: bool
     realtime: bool
     fields: Optional[list[ReportField]] = None
     daily_goals: Goals | None = None
+    streak_mode: StreakMode = StreakMode.strict
 
 
 class ActivityType(BaseModel):


### PR DESCRIPTION
Issue #90 

### Preparation
* comments: Adjust the comment/example for the current streak algorithm.
* refacto: Refactor activity streak calculation, keeping current streak calculation logic.
  - Make the repository return the number of days in the streak, instead of the earliest date in the streak.
  - The future streak calculation logic will evolve: it will ignore days with no activity at all. So returning an "earliest date in the streak" won't help to calculate the number days in the streak.

### New behavior
* Add a new app report configuation: `streak_mode`, with possible values:
  - `strict`: same streak behavior as before.
  - `lax`: days without any activity at all don't break the "streak".
  The values are documented in `app-default.xml`.
* Implement the logic for the `lax` streak mode calculation:
  - If a goal is set (with `daily_goals`): The streak is the number of recent days where the goal was reached, ignoring days without any activity. 
    - A day with activity logged which doesn't meet the goal breaks the streak.
    - A day with no activity logged doesn't break the streak.
  - If no goal is set: The "streak" is simply the number of days in which activity was logged.