### PR TITLE
Fitbit -> Google migration - Step 4 - Fetch activity and sleep data.

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,7 @@ graph
     end
     subgraph Routes
         FitbitRoutes
+        GoogleRoutes
         WithingsRoutes
     end
     subgraph Data
@@ -95,6 +96,7 @@ graph
     subgraph Domain
         subgraph UseCases
             FitbitUseCases
+            GoogleUseCases
             WithingsUseCases
             SlackUseCases
         end
@@ -104,6 +106,7 @@ graph
         end
         subgraph RemoteRepositoryInterfaces
             RemoteFitbitRepository("`*RemoteFitbitRepository*`"):::interface
+            RemoteGoogleRepository("`*RemoteGoogleRepository*`"):::interface
             RemoteWithingsRepository("`*RemoteWithingsRepository*`"):::interface
             RemoteSlackRepository("`*RemoteSlackRepository*`"):::interface
             RemoteOpenAiRepository("`*RemoteOpenAiRepository*`"):::interface
@@ -112,12 +115,14 @@ graph
     subgraph RemoteServices[Remote services]
         subgraph RemoteRepositories
             WebApiFitbitRepository
+            WebApiGoogleRepository
             WebApiWithingsRepository
             WebhookSlackRepository
             WebOpenAiRepository
         end
         subgraph Apis
             FitbitApis
+            GoogleApis
             WithingsApis
             SlackApis
         end
@@ -162,6 +167,7 @@ graph
     end
     subgraph Routes
         FitbitRoutes
+        GoogleRoutes
         WithingsRoutes
     end
     subgraph Data
@@ -174,6 +180,7 @@ graph
     subgraph Domain
         subgraph UseCases
             FitbitUseCases
+            GoogleUseCases
             WithingsUseCases
             SlackUseCases
         end
@@ -183,6 +190,7 @@ graph
         end
         subgraph RemoteRepositoryInterfaces
             RemoteFitbitRepository("`*RemoteFitbitRepository*`"):::interface
+            RemoteGoogleRepository("`*RemoteGoogleRepository*`"):::interface
             RemoteWithingsRepository("`*RemoteWithingsRepository*`"):::interface
             RemoteSlackRepository("`*RemoteSlackRepository*`"):::interface
             RemoteOpenAiRepository("`*RemoteOpenAiRepository*`"):::interface
@@ -191,12 +199,14 @@ graph
     subgraph RemoteServices[Remote services]
         subgraph RemoteRepositories
             WebApiFitbitRepository
+            WebApiGoogleRepository
             WebApiWithingsRepository
             WebhookSlackRepository
             WebOpenAiRepository
         end
         subgraph Apis
             FitbitApis
+            GoogleApis
             WithingsApis
             SlackApis
         end
@@ -207,6 +217,7 @@ graph
     end
     subgraph OAuth
         FitbitOAuth
+        GoogleOAuth
         WithingsOAuth
     end
     subgraph DI
@@ -214,6 +225,7 @@ graph
     Sqlite3Database[(SQlite3Database)]:::external
     WithingsWebServer:::external
     FitbitWebServer:::external
+    GoogleWebServer:::external
     SlackWebServer:::external
     OpenAiWebServer:::external
 
@@ -224,6 +236,7 @@ graph
     DI--creates-->SQLAlchemyFitbitRepository
     DI--creates-->SQLAlchemyWithingsRepository
     DI--creates-->WebApiFitbitRepository
+    DI--creates-->WebApiGoogleRepository
     DI--creates-->WebApiWithingsRepository
     DI--creates-->WebhookSlackRepository
     DI--creates-->WebOpenAiRepository
@@ -239,18 +252,22 @@ graph
     SQLAlchemyWithingsRepository--implements-->LocalWithingsRepository
 
     WebApiFitbitRepository--implements-->RemoteFitbitRepository
+    WebApiGoogleRepository--implements-->RemoteGoogleRepository
     WebApiWithingsRepository--implements-->RemoteWithingsRepository
     WebhookSlackRepository--implements-->RemoteSlackRepository
     WebOpenAiRepository --implements-->RemoteOpenAiRepository
     OpenAiSdk{{OpenAISdk}}
     WebApiFitbitRepository-->FitbitApis
+    WebApiGoogleRepository-->GoogleApis
     WebApiWithingsRepository-->WithingsApis
     WebhookSlackRepository-->SlackApis
     WebOpenAiRepository-->OpenAiSdk
     FitbitApis--http--->FitbitWebServer
+    GoogleApis--http--->GoogleWebServer
     WithingsApis--http--->WithingsWebServer
     SlackApis--http--->SlackWebServer
     FitbitOAuth--http--->FitbitWebServer
+    GoogleOAuth--http--->GoogleWebServer
     WithingsOAuth--http--->WithingsWebServer
     OpenAiSdk--http--->OpenAiWebServer
 

--- a/slackhealthbot/domain/remoterepository/remotegooglerepository.py
+++ b/slackhealthbot/domain/remoterepository/remotegooglerepository.py
@@ -1,8 +1,10 @@
+import datetime as dt
 from abc import ABC, abstractmethod
 
 from pydantic import BaseModel
 
 from slackhealthbot.core.models import OAuthFields
+from slackhealthbot.domain.models.activity import ActivityData
 
 
 class HealthIds(BaseModel):
@@ -22,3 +24,10 @@ class RemoteGoogleRepository(ABC):
         self,
         oauth_fields: OAuthFields,
     ) -> HealthIds: ...
+
+    @abstractmethod
+    async def get_activities_for_date(
+        self,
+        oauth_fields: OAuthFields,
+        when: dt.date,
+    ) -> list[tuple[str, ActivityData]]: ...

--- a/slackhealthbot/domain/remoterepository/remotegooglerepository.py
+++ b/slackhealthbot/domain/remoterepository/remotegooglerepository.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from slackhealthbot.core.models import OAuthFields
 from slackhealthbot.domain.models.activity import ActivityData
+from slackhealthbot.domain.models.sleep import SleepData
 
 
 class HealthIds(BaseModel):
@@ -31,3 +32,10 @@ class RemoteGoogleRepository(ABC):
         oauth_fields: OAuthFields,
         when: dt.date,
     ) -> list[tuple[str, ActivityData]]: ...
+
+    @abstractmethod
+    async def get_sleep(
+        self,
+        oauth_fields: OAuthFields,
+        when: dt.date,
+    ) -> SleepData | None: ...

--- a/slackhealthbot/domain/usecases/fitbit/usecase_get_last_sleep.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_get_last_sleep.py
@@ -6,11 +6,15 @@ from slackhealthbot.containers import Container
 from slackhealthbot.core.models import OAuthFields
 from slackhealthbot.domain.localrepository.localfitbitrepository import (
     LocalFitbitRepository,
+    User,
 )
 from slackhealthbot.domain.models.sleep import SleepData
 from slackhealthbot.domain.models.users import UserLookup
 from slackhealthbot.domain.remoterepository.remotefitbitrepository import (
     RemoteFitbitRepository,
+)
+from slackhealthbot.domain.remoterepository.remotegooglerepository import (
+    RemoteGoogleRepository,
 )
 
 
@@ -19,12 +23,23 @@ async def do(
     user_lookup: UserLookup,
     when: datetime.date,
     local_repo: LocalFitbitRepository = Provide[Container.local_fitbit_repository],
-    remote_repo: RemoteFitbitRepository = Provide[Container.remote_fitbit_repository],
+    remote_fitbit_repo: RemoteFitbitRepository = Provide[
+        Container.remote_fitbit_repository
+    ],
+    remote_google_repo: RemoteGoogleRepository = Provide[
+        Container.remote_google_repository
+    ],
 ) -> SleepData | None:
     oauth_data: OAuthFields = await local_repo.get_oauth_data_by_user_lookup(
         user_lookup
     )
-    return await remote_repo.get_sleep(
+    user: User = await local_repo.get_user_by_lookup(user_lookup)
+    if user.identity.health_user_id is not None:
+        return await remote_google_repo.get_sleep(
+            oauth_fields=oauth_data,
+            when=when,
+        )
+    return await remote_fitbit_repo.get_sleep(
         oauth_fields=oauth_data,
         when=when,
     )

--- a/slackhealthbot/domain/usecases/fitbit/usecase_process_new_activity.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_process_new_activity.py
@@ -17,6 +17,9 @@ from slackhealthbot.domain.models.users import UserLookup
 from slackhealthbot.domain.remoterepository.remotefitbitrepository import (
     RemoteFitbitRepository,
 )
+from slackhealthbot.domain.remoterepository.remotegooglerepository import (
+    RemoteGoogleRepository,
+)
 from slackhealthbot.domain.usecases.slack import usecase_post_activity
 from slackhealthbot.settings import Settings
 
@@ -32,13 +35,22 @@ async def do(  # noqa: PLR0913 deal with this later
     remote_fitbit_repo: RemoteFitbitRepository = Provide[
         Container.remote_fitbit_repository
     ],
+    remote_google_repo: RemoteGoogleRepository = Provide[
+        Container.remote_google_repository
+    ],
 ) -> list[ActivityData]:
     user_identity: UserIdentity = await local_fitbit_repo.get_user_identity(user_lookup)
     user: User = await local_fitbit_repo.get_user_by_lookup(user_lookup)
-    activities = await remote_fitbit_repo.get_activities_for_date(
-        oauth_fields=user.oauth_data,
-        when=when,
-    )
+    if user.identity.health_user_id is not None:
+        activities = await remote_google_repo.get_activities_for_date(
+            oauth_fields=user.oauth_data,
+            when=when,
+        )
+    else:
+        activities = await remote_fitbit_repo.get_activities_for_date(
+            oauth_fields=user.oauth_data,
+            when=when,
+        )
     if not activities:
         return []
 

--- a/slackhealthbot/remoteservices/api/google/activityapi.py
+++ b/slackhealthbot/remoteservices/api/google/activityapi.py
@@ -1,0 +1,162 @@
+import datetime as dt
+import logging
+from typing import Annotated
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+
+from slackhealthbot.core.models import OAuthFields
+from slackhealthbot.oauth import requests
+from slackhealthbot.settings import Settings
+
+
+def parse_seconds_duration(value: str) -> int:
+    return int(value[:-1])
+
+
+DurationS = Annotated[int, BeforeValidator(parse_seconds_duration)]
+
+
+class TimeInHeartRateZones(BaseModel):
+    lightTime: DurationS
+    moderateTime: DurationS
+    vigorousTime: DurationS
+    peakTime: DurationS
+
+
+class MetricsSummary(BaseModel):
+    caloriesKcal: float
+    heartRateZoneDurations: TimeInHeartRateZones
+    distanceMillimeters: int | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class Interval(BaseModel):
+    startTime: dt.datetime
+    endTime: dt.datetime
+    model_config = ConfigDict(extra="allow")
+
+
+class Exercise(BaseModel):
+    interval: Interval
+    metricsSummary: MetricsSummary
+    activeDuration: DurationS
+    exerciseType: str
+    displayName: str
+    model_config = ConfigDict(extra="allow")
+
+
+class Distance(BaseModel):
+    millimeters: int
+    interval: Interval
+    model_config = ConfigDict(extra="allow")
+
+
+class DataPoint(BaseModel):
+    exercise: Exercise | None = None
+    distance: Distance | None = None
+    name: str | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class HealthActivities(BaseModel):
+    # https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints#DataPoint
+    """
+    {
+      "dataPoints": [
+        {
+          "name": "users/xxx/dataTypes/exercise/dataPoints/yyy",
+          "dataSource": {
+            "recordingMethod": "MANUAL",
+            "application": {
+              "webClientId": "228TSL"
+            },
+            "platform": "FITBIT"
+          },
+          "exercise": {
+            "interval": {
+              "startTime": "2026-04-04T22:53:00Z",
+              "startUtcOffset": "7200s",
+              "endTime": "2026-04-04T23:23:00Z",
+              "endUtcOffset": "7200s"
+            },
+            "exerciseType": "OTHER",
+            "metricsSummary": {
+              "caloriesKcal": 23,
+              "activeZoneMinutes": "0",
+              "heartRateZoneDurations": {
+                "lightTime": "0s",
+                "moderateTime": "0s",
+                "vigorousTime": "0s",
+                "peakTime": "0s"
+              }
+            },
+            "exerciseMetadata": {
+              "hasGps": false
+            },
+            "displayName": "Tapis de course",
+            "activeDuration": "1800s",
+            "updateTime": "2026-04-04T23:23:24.269034Z",
+            "createTime": "2026-04-04T23:23:24.269034Z"
+          }
+        }
+      ],
+      "nextPageToken": ""
+    }
+    """
+
+    dataPoints: list[DataPoint] = Field(default_factory=list)
+    model_config = ConfigDict(extra="allow")
+
+
+async def get_activities_for_date(
+    oauth_token: OAuthFields,
+    when: dt.date,
+    settings: Settings,
+) -> HealthActivities | None:
+    start_date_str = when.strftime("%Y-%m-%d")
+    end_date_str = (when + dt.timedelta(days=1)).strftime("%Y-%m-%d")
+    exercise_response = await requests.get(
+        provider=settings.google_oauth_settings.name,
+        token=oauth_token,
+        url="/v4/users/me/dataTypes/exercise/dataPoints",
+        params={
+            "filter": f"exercise.interval.civil_start_time >= {start_date_str} AND exercise.interval.civil_start_time < {end_date_str}",
+        },
+    )
+    logging.info(f"Google health exercise response: {exercise_response.json()}")
+    exercises = HealthActivities.model_validate(exercise_response.json())
+    if not exercises.dataPoints:
+        return exercises
+
+    min_start_time = min((x.exercise.interval.startTime for x in exercises.dataPoints))
+    max_end_time = max((x.exercise.interval.endTime for x in exercises.dataPoints))
+    min_start_time_str = min_start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    max_end_time_str = max_end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    distance_response = await requests.get(
+        provider=settings.google_oauth_settings.name,
+        token=oauth_token,
+        url="/v4/users/me/dataTypes/distance/dataPoints",
+        params={
+            "pageSize": 10000,
+            "filter": f'distance.interval.start_time >= "{min_start_time_str}" AND distance.interval.start_time < "{max_end_time_str}"',
+        },
+    )
+    logging.info(f"Google health distance response: {distance_response.json()}")
+    distances = HealthActivities.model_validate(distance_response.json())
+
+    for exercise_data_point in exercises.dataPoints:
+        exercise = exercise_data_point.exercise
+        if exercise.metricsSummary.distanceMillimeters is None:
+            # WHY GOOGLE, WHY??? :(
+            # Calculate the distance
+            exercise.metricsSummary.distanceMillimeters = 0
+            for distance_data_point in distances.dataPoints:
+                distance = distance_data_point.distance
+                if (
+                    exercise.interval.startTime
+                    <= distance.interval.startTime
+                    <= exercise.interval.endTime
+                ):
+                    exercise.metricsSummary.distanceMillimeters += distance.millimeters
+
+    return exercises

--- a/slackhealthbot/remoteservices/api/google/sleepapi.py
+++ b/slackhealthbot/remoteservices/api/google/sleepapi.py
@@ -130,6 +130,12 @@ async def get_sleep(
     # of the given date.
 
     google_sleep.dataPoints = [
-        x for x in google_sleep.dataPoints if x.sleep.interval.endTime.date() == when
+        x
+        for x in google_sleep.dataPoints
+        if (
+            x.sleep.interval.endTime.replace(tzinfo=None)
+            + dt.timedelta(seconds=x.sleep.interval.endUtcOffset)
+        ).date()
+        == when
     ]
     return google_sleep

--- a/slackhealthbot/remoteservices/api/google/sleepapi.py
+++ b/slackhealthbot/remoteservices/api/google/sleepapi.py
@@ -1,0 +1,135 @@
+import datetime as dt
+import logging
+from typing import Annotated
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, NonNegativeInt
+
+from slackhealthbot.core.models import OAuthFields
+from slackhealthbot.oauth import requests
+from slackhealthbot.settings import Settings
+
+
+def parse_seconds_duration(value: str) -> int:
+    return int(value[:-1])
+
+
+DurationS = Annotated[int, BeforeValidator(parse_seconds_duration)]
+
+
+class Interval(BaseModel):
+    startTime: dt.datetime
+    startUtcOffset: DurationS
+    endTime: dt.datetime
+    endUtcOffset: DurationS
+    model_config = ConfigDict(extra="allow")
+
+
+class SleepSummary(BaseModel):
+    minutesAwake: NonNegativeInt
+    minutesAsleep: NonNegativeInt
+    model_config = ConfigDict(extra="allow")
+
+
+class SleepMetaData(BaseModel):
+    nap: bool = False  # This is documented by Google but not returned!
+    model_config = ConfigDict(extra="allow")
+
+
+class Sleep(BaseModel):
+    interval: Interval
+    summary: SleepSummary
+    metadata: SleepMetaData
+    model_config = ConfigDict(extra="allow")
+
+
+class DataPoint(BaseModel):
+    sleep: Sleep
+    model_config = ConfigDict(extra="allow")
+
+
+class GoogleSleep(BaseModel):
+    dataPoints: list[DataPoint] = Field(default_factory=list)
+    model_config = ConfigDict(extra="allow")
+
+
+async def get_sleep(
+    oauth_token: OAuthFields,
+    when: dt.date,
+    settings: Settings,
+) -> GoogleSleep | None:
+    # https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints/list
+    end_date_str = (when + dt.timedelta(days=1)).strftime("%Y-%m-%d")
+    """
+    Example:
+      "dataPoints": [
+    {
+      "name": "users/xxx/dataTypes/sleep/dataPoints/yyy",
+      "dataSource": {
+        "recordingMethod": "MANUAL",
+        "platform": "FITBIT"
+      },
+      "sleep": {
+        "interval": {
+          "startTime": "2026-04-04T18:39:00Z",
+          "startUtcOffset": "7200s",
+          "endTime": "2026-04-05T02:39:00Z",
+          "endUtcOffset": "7200s"
+        },
+        "type": "CLASSIC",
+        "stages": [
+          {
+            "startTime": "2026-04-04T18:39:00Z",
+            "startUtcOffset": "7200s",
+            "endTime": "2026-04-05T02:39:00Z",
+            "endUtcOffset": "7200s",
+            "type": "ASLEEP",
+            "createTime": "2026-04-05T02:39:44.295167Z",
+            "updateTime": "2026-04-05T02:39:44.295167Z"
+          }
+        ],
+        "metadata": {
+          "stagesStatus": "REJECTED_SERVER",
+          "processed": true,
+          "externalId": ""
+        },
+        "summary": {
+          "minutesInSleepPeriod": "480",
+          "minutesAfterWakeUp": "0",
+          "minutesToFallAsleep": "0",
+          "minutesAsleep": "480",
+          "minutesAwake": "0",
+          "stagesSummary": [
+            {
+              "type": "ASLEEP",
+              "minutes": "480",
+              "count": "1"
+            }   
+          ]   
+        },  
+        "createTime": "2026-04-05T02:39:44.295167Z",
+        "updateTime": "2026-04-05T02:39:44.648127Z"
+      }   
+    },
+    """
+    # From the api documentation:
+    # Data points in the response will be ordered by the interval start time in descending order.
+    # Note that the api doesn't expose any ordering parameters.
+    response = await requests.get(
+        provider=settings.google_oauth_settings.name,
+        token=oauth_token,
+        url="/v4/users/me/dataTypes/sleep/dataPoints",
+        params={
+            "filter": f"sleep.interval.civil_end_time < {end_date_str}",
+        },
+    )
+    logging.info(f"Google health sleep response: {response.json()}")
+
+    google_sleep = GoogleSleep.model_validate(response.json())
+    # We were only able to request sleeps ending before the end of the given date.
+    # We have to filter by hand to exclude any sleeps ended before the beginning
+    # of the given date.
+
+    google_sleep.dataPoints = [
+        x for x in google_sleep.dataPoints if x.sleep.interval.endTime.date() == when
+    ]
+    return google_sleep

--- a/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
+++ b/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 
 from slackhealthbot.core.models import OAuthFields
 from slackhealthbot.domain.models.activity import (
@@ -6,11 +7,12 @@ from slackhealthbot.domain.models.activity import (
     ActivityZone,
     ActivityZoneMinutes,
 )
+from slackhealthbot.domain.models.sleep import SleepData
 from slackhealthbot.domain.remoterepository.remotegooglerepository import (
     HealthIds,
     RemoteGoogleRepository,
 )
-from slackhealthbot.remoteservices.api.google import activityapi, identityapi
+from slackhealthbot.remoteservices.api.google import activityapi, identityapi, sleepapi
 from slackhealthbot.settings import Settings
 
 
@@ -66,6 +68,18 @@ class WebApiGoogleRepository(RemoteGoogleRepository):
         ]
         return domain_activities
 
+    async def get_sleep(
+        self,
+        oauth_fields: OAuthFields,
+        when: datetime.date,
+    ) -> SleepData | None:
+        sleep: sleepapi.GoogleSleep = await sleepapi.get_sleep(
+            oauth_token=oauth_fields,
+            when=when,
+            settings=self.settings,
+        )
+        return remote_service_sleep_to_domain_sleep(sleep) if sleep else None
+
 
 def remote_service_activity_type(exercise: activityapi.Exercise) -> int:
     # https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints#Exercise.ExerciseType
@@ -120,4 +134,27 @@ def remote_service_activity_to_domain_activity(
                 // 60,
             ),
         ],
+    )
+
+
+def remote_service_sleep_to_domain_sleep(
+    remote: sleepapi.GoogleSleep | None,
+) -> SleepData | None:
+    if not remote:
+        return None
+    main_sleep_item = next(
+        (item for item in remote.dataPoints if item.sleep.metadata.nap is False), None
+    )
+    if not main_sleep_item:
+        logging.warning("No main sleep found")
+        return None
+
+    interval: sleepapi.Interval = main_sleep_item.sleep.interval
+    return SleepData(
+        start_time=interval.startTime.replace(tzinfo=None)
+        + datetime.timedelta(seconds=interval.startUtcOffset),
+        end_time=interval.endTime.replace(tzinfo=None)
+        + datetime.timedelta(seconds=interval.endUtcOffset),
+        sleep_minutes=main_sleep_item.sleep.summary.minutesAsleep,
+        wake_minutes=main_sleep_item.sleep.summary.minutesAwake,
     )

--- a/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
+++ b/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
@@ -1,11 +1,16 @@
 import datetime
 
 from slackhealthbot.core.models import OAuthFields
+from slackhealthbot.domain.models.activity import (
+    ActivityData,
+    ActivityZone,
+    ActivityZoneMinutes,
+)
 from slackhealthbot.domain.remoterepository.remotegooglerepository import (
     HealthIds,
     RemoteGoogleRepository,
 )
-from slackhealthbot.remoteservices.api.google import identityapi
+from slackhealthbot.remoteservices.api.google import activityapi, identityapi
 from slackhealthbot.settings import Settings
 
 
@@ -39,3 +44,80 @@ class WebApiGoogleRepository(RemoteGoogleRepository):
             fitbit_user_id=identity.legacyUserId,
             health_user_id=identity.healthUserId,
         )
+
+    async def get_activities_for_date(
+        self,
+        oauth_fields: OAuthFields,
+        when: datetime.date,
+    ) -> list[tuple[str, ActivityData]]:
+        google_activities: activityapi.HealthActivities = (
+            await activityapi.get_activities_for_date(
+                oauth_token=oauth_fields,
+                when=when,
+                settings=self.settings,
+            )
+        )
+        domain_activities = [
+            (
+                x.exercise.displayName,
+                remote_service_activity_to_domain_activity(x),
+            )
+            for x in google_activities.dataPoints
+        ]
+        return domain_activities
+
+
+def remote_service_activity_type(exercise: activityapi.Exercise) -> int:
+    # https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints#Exercise.ExerciseType
+    # WHY GOOGLE?
+    # Google has only a handful of exercise types, much less than the Fitbit api.
+    # "Treadmill" isn't one of them, unfortunately.
+    # Just by testing, we see that the displayName was "Tapis de course", for one account, for
+    # a treadmill activity.
+    # This is not very reliable. We'll have to revisit this when the Google apis become more stable.
+    if exercise.exerciseType == "OTHER":
+        if exercise.displayName == "Tapis de course":
+            return 91064
+    if exercise.exerciseType == "WALKING":
+        return 90013
+    if exercise.exerciseType == "BIKING":
+        return 90001
+
+    return 99999
+
+
+def remote_service_activity_to_domain_activity(
+    data_point: activityapi.DataPoint,
+) -> ActivityData:
+    data_point_id = data_point.name.rsplit("/", 1)[-1]
+    return ActivityData(
+        log_id=data_point_id,
+        type_id=remote_service_activity_type(data_point.exercise),
+        logged_at=data_point.exercise.interval.startTime,
+        calories=data_point.exercise.metricsSummary.caloriesKcal,
+        distance_km=data_point.exercise.metricsSummary.distanceMillimeters
+        / (1000 * 1000),
+        total_minutes=data_point.exercise.activeDuration / 60,
+        zone_minutes=[
+            ActivityZoneMinutes(
+                zone=ActivityZone.PEAK,
+                minutes=data_point.exercise.metricsSummary.heartRateZoneDurations.peakTime
+                // 60,
+            ),
+            ActivityZoneMinutes(
+                zone=ActivityZone.CARDIO,
+                minutes=data_point.exercise.metricsSummary.heartRateZoneDurations.vigorousTime
+                // 60,
+            ),
+            ActivityZoneMinutes(
+                zone=ActivityZone.FAT_BURN,
+                minutes=data_point.exercise.metricsSummary.heartRateZoneDurations.moderateTime
+                // 60,
+            ),
+            ActivityZoneMinutes(
+                zone=ActivityZone.OUT_OF_ZONE,
+                minutes=data_point.exercise.metricsSummary.heartRateZoneDurations.lightTime
+                // 60,
+            ),
+        ],
+    )

--- a/tests/tasks/test_google_oauth.py
+++ b/tests/tasks/test_google_oauth.py
@@ -1,0 +1,141 @@
+import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import Response
+from respx import MockRouter
+
+from slackhealthbot.data.database.models import FitbitUser, User
+from slackhealthbot.domain.localrepository.localfitbitrepository import (
+    LocalFitbitRepository,
+)
+from slackhealthbot.domain.models.sleep import SleepData
+from slackhealthbot.settings import Settings
+from slackhealthbot.tasks.fitbitpoll import Cache, do_poll
+from tests.testsupport.factories.factories import (
+    FitbitActivityFactory,
+    FitbitUserFactory,
+    UserFactory,
+)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_ok(  # noqa: PLR0913
+    client: TestClient,
+    respx_mock: MockRouter,
+    fitbit_factories: tuple[UserFactory, FitbitUserFactory, FitbitActivityFactory],
+    local_fitbit_repository: LocalFitbitRepository,
+    settings: Settings,
+):
+    """
+    Given a user whose access token is expired
+    When we poll google for sleep data
+    Then the access token is refreshed
+    And the latest sleep data is updated in the database,
+    And the message is posted to slack.
+    """
+
+    user_factory, fitbit_user_factory, _ = fitbit_factories
+
+    # Given a user
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
+        user_id=user.id,
+        oauth_userid="googleuser123",
+        health_user_id="healthuserid123",
+        oauth_access_token="some old access token",
+        oauth_refresh_token="some old refresh token",
+        oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(days=1),
+    )
+
+    # Mock google oauth refresh token success
+    oauth_token_refresh_request = respx_mock.post(
+        url="https://oauth2.googleapis.com/token",
+    ).mock(
+        Response(
+            status_code=200,
+            json={
+                "user_id": user.fitbit.oauth_userid,
+                "access_token": "some new access token",
+                "refresh_token": "some old refresh token",
+                "expires_in": 600,
+            },
+        )
+    )
+
+    # Mock google endpoint to return no activity data
+    respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/exercise/dataPoints",
+    ).mock(Response(status_code=200, json={}))
+
+    respx_mock.get(settings.google_oauth_settings.oidc_url).pass_through()
+    respx_mock.get("https://www.googleapis.com/oauth2/v3/certs").pass_through()
+
+    # Mock google endpoint to return some sleep data
+    google_sleep_request = respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/sleep/dataPoints",
+    ).mock(
+        Response(
+            status_code=200,
+            json={
+                "dataPoints": [
+                    {
+                        "sleep": {
+                            "interval": {
+                                "startTime": "2026-04-04T18:39:00Z",
+                                "startUtcOffset": "7200s",
+                                "endTime": "2026-04-05T02:39:00Z",
+                                "endUtcOffset": "7200s",
+                            },
+                            "metadata": {},
+                            "summary": {
+                                "minutesAsleep": "480",
+                                "minutesAwake": "0",
+                            },
+                        },
+                    }
+                ]
+            },
+        )
+    )
+
+    # Mock an empty ok response from the slack webhook
+    slack_request = respx_mock.post(
+        f"{settings.secret_settings.slack_webhook_url}"
+    ).mock(return_value=Response(200))
+
+    # When we poll for new sleep data
+    # Use the client as a context manager so that the app lifespan hook is called
+    # https://fastapi.tiangolo.com/advanced/testing-events/
+    with client:
+        await do_poll(
+            cache=Cache(),
+            when=datetime.date(2026, 4, 5),
+        )
+
+        repo_user = await local_fitbit_repository.get_user_by_lookup(fitbit_user.lookup)
+
+        # Then the access token is refreshed.
+        assert google_sleep_request.call_count == 1
+        assert (
+            google_sleep_request.calls[0].request.headers["authorization"]
+            == "Bearer some new access token"
+        )
+        assert oauth_token_refresh_request.call_count == 1
+        assert repo_user.oauth_data.oauth_access_token == "some new access token"
+        assert repo_user.oauth_data.oauth_refresh_token == "some old refresh token"
+
+        # And the latest sleep data is updated in the database
+        actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+            user_lookup=fitbit_user.lookup,
+        )
+        assert actual_last_sleep_data == SleepData(
+            start_time=datetime.datetime(2026, 4, 4, 20, 39),
+            end_time=datetime.datetime(2026, 4, 5, 4, 39),
+            sleep_minutes=480,
+            wake_minutes=0,
+        )
+
+    # And a message was sent to slack
+    assert slack_request.call_count == 1

--- a/tests/tasks/test_google_oauth.py
+++ b/tests/tasks/test_google_oauth.py
@@ -1,4 +1,6 @@
 import datetime
+import json
+import re
 
 import pytest
 from fastapi.testclient import TestClient
@@ -139,3 +141,84 @@ async def test_refresh_token_ok(  # noqa: PLR0913
 
     # And a message was sent to slack
     assert slack_request.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_logged_out(  # noqa: PLR0913
+    local_fitbit_repository: LocalFitbitRepository,
+    client: TestClient,
+    respx_mock: MockRouter,
+    fitbit_factories: tuple[UserFactory, FitbitUserFactory, FitbitActivityFactory],
+    settings: Settings,
+):
+    """
+    Given a user whose access token is invalid
+    When we poll google for new data
+    Then no sleep is updated in the database
+    And a message is posted to slack about the user being logged out
+    """
+
+    user_factory, fitbit_user_factory, _ = fitbit_factories
+
+    # Given a user
+    user: User = user_factory.create(fitbit=None, slack_alias="jdoe")
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
+        user_id=user.id,
+        health_user_id="healthuser123",
+        oauth_access_token="some invalid access token",
+        last_sleep_sleep_minutes=None,
+        oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+
+    respx_mock.get(settings.google_oauth_settings.oidc_url).pass_through()
+    # Mock google endpoints to return an unauthorized error
+    unauthorized_payload = {
+        "error": {
+            "code": 401,
+            "message": "Request had invalid authentication credentials. Expected OAuth 2 access token, login ...m/identity/sign-in/web/devconsole-project.",
+            "status": "UNAUTHENTICATED",
+        }
+    }
+    respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/sleep/dataPoints",
+    ).mock(Response(status_code=401, json=unauthorized_payload))
+    google_activity_request = respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/exercise/dataPoints",
+    ).mock(Response(status_code=401, json=unauthorized_payload))
+
+    # Mock an empty ok response from the slack webhook
+    slack_request = respx_mock.post(
+        f"{settings.secret_settings.slack_webhook_url}"
+    ).mock(return_value=Response(200))
+
+    # When we poll for new data
+    # Use the client as a context manager so that the app lifespan hook is called
+    # https://fastapi.tiangolo.com/advanced/testing-events/
+    with client:
+        await do_poll(
+            local_fitbit_repo=local_fitbit_repository,
+            cache=Cache(),
+            when=datetime.date(2023, 1, 23),
+        )
+
+    repo_user = await local_fitbit_repository.get_user_by_lookup(fitbit_user.lookup)
+
+    # Then the access token is not refreshed.
+    assert google_activity_request.call_count == 1
+    assert repo_user.oauth_data.oauth_access_token == "some invalid access token"
+
+    # And no new sleep data is updated in the database
+    sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+        fitbit_user.lookup
+    )
+    assert sleep_data is None
+
+    # And a message was sent to slack about the user being logged out
+    assert slack_request.call_count == 1
+    actual_message = json.loads(slack_request.calls[0].request.content)["text"].replace(
+        "\n", ""
+    )
+    assert re.search(
+        "Oh no <@jdoe>, looks like you were logged out of google! 😳.", actual_message
+    )

--- a/tests/tasks/test_google_poll.py
+++ b/tests/tasks/test_google_poll.py
@@ -9,6 +9,11 @@ from slackhealthbot.data.database.models import FitbitUser, User
 from slackhealthbot.domain.localrepository.localfitbitrepository import (
     LocalFitbitRepository,
 )
+from slackhealthbot.domain.models.activity import (
+    ActivityData,
+    ActivityZone,
+    ActivityZoneMinutes,
+)
 from slackhealthbot.domain.models.sleep import SleepData
 from slackhealthbot.settings import Settings
 from slackhealthbot.tasks.fitbitpoll import Cache, do_poll
@@ -106,6 +111,148 @@ async def test_google_poll_sleep(  # noqa: PLR0913
         end_time=datetime.datetime(2026, 4, 5, 4, 39),
         sleep_minutes=480,
         wake_minutes=0,
+    )
+
+    assert slack_request.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_google_poll_activity(  # noqa: PLR0913
+    local_fitbit_repository: LocalFitbitRepository,
+    respx_mock: MockRouter,
+    fitbit_factories: tuple[UserFactory, FitbitUserFactory, FitbitActivityFactory],
+    client: TestClient,
+    settings: Settings,
+):
+    """
+    Given a user
+    When we poll google to get new activity data,
+    Then the activity data is updated in the database,
+    And a message is posted to slack.
+    """
+    user_factory, fitbit_user_factory, _ = fitbit_factories
+
+    # Given a user with the given previous sleep data
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
+        user_id=user.id,
+        health_user_id="googlehealth123",
+        oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+
+    # Mock google endpoint to return no sleep data
+    respx_mock.get(settings.google_oauth_settings.oidc_url).pass_through()
+    respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/sleep/dataPoints",
+    ).mock(Response(status_code=200, json={}))
+
+    # Mock google endpoint to return some activity data
+    respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/exercise/dataPoints",
+    ).mock(
+        Response(
+            status_code=200,
+            json={
+                "dataPoints": [
+                    {
+                        "name": "users/xxx/dataTypes/exercise/dataPoints/yyy",
+                        "exercise": {
+                            "interval": {
+                                "startTime": "2026-04-04T22:53:00Z",
+                                "startUtcOffset": "7200s",
+                                "endTime": "2026-04-04T23:23:00Z",
+                                "endUtcOffset": "7200s",
+                            },
+                            "exerciseType": "WALKING",
+                            "metricsSummary": {
+                                "caloriesKcal": 23,
+                                "activeZoneMinutes": "0",
+                                "heartRateZoneDurations": {
+                                    "lightTime": "0s",
+                                    "moderateTime": "63s",
+                                    "vigorousTime": "0s",
+                                    "peakTime": "0s",
+                                },
+                            },
+                            "displayName": "Tapis de course",
+                            "activeDuration": "1800s",
+                        },
+                    }
+                ],
+            },
+        )
+    )
+    # Mock google endpoint to return some distance data
+    respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/distance/dataPoints",
+    ).mock(
+        Response(
+            status_code=200,
+            json={
+                "dataPoints": [
+                    {
+                        "distance": {
+                            "interval": {
+                                "startTime": "2026-04-04T22:53:00Z",
+                                "startUtcOffset": "7200s",
+                                "endTime": "2026-04-04T23:03:00Z",
+                                "endUtcOffset": "7200s",
+                            },
+                            "millimeters": 65381,
+                        },
+                    },
+                    {
+                        "distance": {
+                            "interval": {
+                                "startTime": "2026-04-04T23:03:00Z",
+                                "startUtcOffset": "7200s",
+                                "endTime": "2026-04-04T23:23:00Z",
+                                "endUtcOffset": "7200s",
+                            },
+                            "millimeters": 55334,
+                        },
+                    },
+                ],
+            },
+        )
+    )
+
+    # Mock an empty ok response from the slack webhook
+    slack_request = respx_mock.post(
+        f"{settings.secret_settings.slack_webhook_url}"
+    ).mock(return_value=Response(200))
+
+    # When we poll for new sleep data
+    # Use the client as a context manager so that the app lifespan hook is called
+    # https://fastapi.tiangolo.com/advanced/testing-events/
+    with client:
+        await do_poll(
+            local_fitbit_repo=local_fitbit_repository,
+            cache=Cache(),
+            when=datetime.date(2026, 4, 4),
+        )
+
+    # Then the activity data is updated in the database
+    actual_activity_data = (
+        await local_fitbit_repository.get_latest_activity_by_user_and_type(
+            user_lookup=fitbit_user.lookup,
+            type_id=90013,
+        )
+    )
+    assert actual_activity_data == ActivityData(
+        log_id="yyy",
+        type_id=90013,
+        logged_at=datetime.datetime(2026, 4, 4, 22, 53),
+        total_minutes=30,
+        calories=23,
+        distance_km=pytest.approx(0.120715),
+        zone_minutes=[
+            ActivityZoneMinutes(
+                zone=ActivityZone.FAT_BURN,
+                minutes=1,
+            ),
+        ],
     )
 
     assert slack_request.call_count == 1

--- a/tests/tasks/test_google_poll.py
+++ b/tests/tasks/test_google_poll.py
@@ -1,0 +1,111 @@
+import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import Response
+from respx import MockRouter
+
+from slackhealthbot.data.database.models import FitbitUser, User
+from slackhealthbot.domain.localrepository.localfitbitrepository import (
+    LocalFitbitRepository,
+)
+from slackhealthbot.domain.models.sleep import SleepData
+from slackhealthbot.settings import Settings
+from slackhealthbot.tasks.fitbitpoll import Cache, do_poll
+from tests.testsupport.factories.factories import (
+    FitbitActivityFactory,
+    FitbitUserFactory,
+    UserFactory,
+)
+
+
+@pytest.mark.asyncio
+async def test_google_poll_sleep(  # noqa: PLR0913
+    local_fitbit_repository: LocalFitbitRepository,
+    respx_mock: MockRouter,
+    fitbit_factories: tuple[UserFactory, FitbitUserFactory, FitbitActivityFactory],
+    client: TestClient,
+    settings: Settings,
+):
+    """
+    Given a user with previous sleep data logged
+    When we poll google to get new sleep data
+    Then the last sleep is updated in the database,
+    And a message is posted to slack.
+    """
+    user_factory, fitbit_user_factory, _ = fitbit_factories
+
+    # Given a user with the given previous sleep data
+    user: User = user_factory.create(fitbit=None)
+    fitbit_user: FitbitUser = fitbit_user_factory.create(
+        user_id=user.id,
+        last_sleep_start_time=datetime.datetime(2023, 5, 11, 23, 39, 0),
+        last_sleep_end_time=datetime.datetime(2023, 5, 12, 8, 28, 0),
+        last_sleep_sleep_minutes=449,
+        last_sleep_wake_minutes=80,
+        health_user_id="googlehealth123",
+        oauth_expiration_date=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+
+    # Mock google endpoint to return no activity data
+    respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/exercise/dataPoints",
+    ).mock(Response(status_code=200, json={}))
+
+    # Mock google endpoint to return some sleep data
+    respx_mock.get(settings.google_oauth_settings.oidc_url).pass_through()
+    respx_mock.get(
+        url=f"{settings.google_oauth_settings.base_url}/v4/users/me/dataTypes/sleep/dataPoints",
+    ).mock(
+        Response(
+            status_code=200,
+            json={
+                "dataPoints": [
+                    {
+                        "sleep": {
+                            "interval": {
+                                "startTime": "2026-04-04T18:39:00Z",
+                                "startUtcOffset": "7200s",
+                                "endTime": "2026-04-05T02:39:00Z",
+                                "endUtcOffset": "7200s",
+                            },
+                            "metadata": {},
+                            "summary": {
+                                "minutesAsleep": "480",
+                                "minutesAwake": "0",
+                            },
+                        },
+                    }
+                ]
+            },
+        )
+    )
+
+    # Mock an empty ok response from the slack webhook
+    slack_request = respx_mock.post(
+        f"{settings.secret_settings.slack_webhook_url}"
+    ).mock(return_value=Response(200))
+
+    # When we poll for new sleep data
+    # Use the client as a context manager so that the app lifespan hook is called
+    # https://fastapi.tiangolo.com/advanced/testing-events/
+    with client:
+        await do_poll(
+            local_fitbit_repo=local_fitbit_repository,
+            cache=Cache(),
+            when=datetime.date(2026, 4, 5),
+        )
+
+    # Then the last sleep data is updated in the database
+    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+        user_lookup=fitbit_user.lookup,
+    )
+    assert actual_last_sleep_data == SleepData(
+        start_time=datetime.datetime(2026, 4, 4, 20, 39),
+        end_time=datetime.datetime(2026, 4, 5, 4, 39),
+        sleep_minutes=480,
+        wake_minutes=0,
+    )
+
+    assert slack_request.call_count == 1


### PR DESCRIPTION
Fetch activity and sleep data from google.

Add some oauth2 token refresh tests. This wasn't possible in #131, because there was no route which would trigger a token refresh or logout.

* #125