### PR TITLE
Fitbit -> Google migration - Step 2 - Support user lookup by either fitbit legacy id or new health id

### DIFF
--- a/alembic/versions/2026_04_05_2022-43e65aff739e_add_fitbit_user_id_and_health_user_id_.py
+++ b/alembic/versions/2026_04_05_2022-43e65aff739e_add_fitbit_user_id_and_health_user_id_.py
@@ -1,0 +1,34 @@
+"""Add fitbit_user_id and health_user_id to fitbit_users
+
+Revision ID: 43e65aff739e
+Revises: 08b4c0449799
+Create Date: 2026-04-05 19:03:36.786130
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "43e65aff739e"
+down_revision = "f02452713b7f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("fitbit_users", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("fitbit_user_id", sa.String(length=40), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("health_user_id", sa.String(length=63), nullable=True)
+        )
+    op.execute("UPDATE fitbit_users SET fitbit_user_id = oauth_userid")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("fitbit_users", schema=None) as batch_op:
+        batch_op.drop_column("health_user_id")
+        batch_op.drop_column("fitbit_user_id")

--- a/slackhealthbot/data/database/models.py
+++ b/slackhealthbot/data/database/models.py
@@ -5,6 +5,12 @@ from typing import Optional
 from sqlalchemy import Float, ForeignKey, String, func
 from sqlalchemy.orm import Mapped, declarative_base, mapped_column, relationship
 
+from slackhealthbot.domain.models.users import (
+    FitbitUserLookup,
+    HealthUserLookup,
+    UserLookup,
+)
+
 Base = declarative_base()
 
 
@@ -59,6 +65,14 @@ class FitbitUser(TimestampMixin, Base):
     last_sleep_end_time: Mapped[Optional[datetime]] = mapped_column()
     last_sleep_sleep_minutes: Mapped[Optional[int]] = mapped_column()
     last_sleep_wake_minutes: Mapped[Optional[int]] = mapped_column()
+
+    @property
+    def lookup(self) -> UserLookup:
+        if self.health_user_id:
+            return HealthUserLookup(user_id=self.health_user_id)
+        # We should have a fitbit_user_id if we don't have a health_user_id.
+        # No need to handle the case where both are None. Shouldn't happen!
+        return FitbitUserLookup(user_id=self.fitbit_user_id)
 
 
 class FitbitActivity(TimestampMixin, Base):

--- a/slackhealthbot/data/database/models.py
+++ b/slackhealthbot/data/database/models.py
@@ -53,6 +53,8 @@ class FitbitUser(TimestampMixin, Base):
     oauth_refresh_token: Mapped[Optional[str]] = mapped_column(String(512))
     oauth_userid: Mapped[str] = mapped_column(String(40))
     oauth_expiration_date: Mapped[Optional[datetime]] = mapped_column()
+    fitbit_user_id: Mapped[Optional[str]] = mapped_column(String(40))
+    health_user_id: Mapped[Optional[str]] = mapped_column(String(63))
     last_sleep_start_time: Mapped[Optional[datetime]] = mapped_column()
     last_sleep_end_time: Mapped[Optional[datetime]] = mapped_column()
     last_sleep_sleep_minutes: Mapped[Optional[int]] = mapped_column()

--- a/slackhealthbot/data/repositories/sqlalchemyfitbitrepository.py
+++ b/slackhealthbot/data/repositories/sqlalchemyfitbitrepository.py
@@ -34,7 +34,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
     async def create_user(
         self,
         slack_alias: str,
-        fitbit_userid: str,
+        fitbit_user_id: str | None,
         oauth_data: OAuthFields,
     ) -> User:
         user = (
@@ -52,10 +52,11 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
         fitbit_user = models.FitbitUser(
             user_id=user.id,
-            oauth_userid=fitbit_userid,
+            oauth_userid=oauth_data.oauth_userid,
             oauth_access_token=oauth_data.oauth_access_token,
             oauth_refresh_token=oauth_data.oauth_refresh_token,
             oauth_expiration_date=oauth_data.oauth_expiration_date,
+            fitbit_user_id=fitbit_user_id,
         )
         self.db.add(fitbit_user)
         await self.db.commit()
@@ -63,11 +64,11 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
         return User(
             identity=UserIdentity(
-                fitbit_userid=fitbit_user.oauth_userid,
+                fitbit_userid=fitbit_user.fitbit_user_id,
                 slack_alias=slack_alias,
             ),
             oauth_data=OAuthFields(
-                oauth_userid=fitbit_userid,
+                oauth_userid=oauth_data.oauth_userid,
                 oauth_access_token=fitbit_user.oauth_access_token,
                 oauth_refresh_token=fitbit_user.oauth_refresh_token,
                 oauth_expiration_date=fitbit_user.oauth_expiration_date.replace(
@@ -84,12 +85,12 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             await self.db.scalars(
                 statement=select(models.User)
                 .join(models.User.fitbit)
-                .where(models.FitbitUser.oauth_userid == fitbit_userid)
+                .where(models.FitbitUser.fitbit_user_id == fitbit_userid)
             )
         ).one_or_none()
         return (
             UserIdentity(
-                fitbit_userid=user.fitbit.oauth_userid,
+                fitbit_userid=user.fitbit.fitbit_user_id,
                 slack_alias=user.slack_alias,
             )
             if user
@@ -103,7 +104,10 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             statement=select(models.User).join(models.User.fitbit)
         )
         return [
-            UserIdentity(fitbit_userid=x.fitbit.oauth_userid, slack_alias=x.slack_alias)
+            UserIdentity(
+                fitbit_userid=x.fitbit.fitbit_user_id,
+                slack_alias=x.slack_alias,
+            )
             for x in users
         ]
 
@@ -114,7 +118,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         fitbit_user: models.FitbitUser = (
             await self.db.scalars(
                 statement=select(models.FitbitUser).where(
-                    models.FitbitUser.oauth_userid == fitbit_userid
+                    models.FitbitUser.fitbit_user_id == fitbit_userid
                 )
             )
         ).one()
@@ -135,18 +139,18 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             await self.db.scalars(
                 statement=select(models.User)
                 .join(models.User.fitbit)
-                .where(models.FitbitUser.oauth_userid == fitbit_userid)
+                .where(models.FitbitUser.fitbit_user_id == fitbit_userid)
             )
         ).one_or_none()
         if not user:
             raise UnknownUserException
         return User(
             identity=UserIdentity(
-                fitbit_userid=user.fitbit.oauth_userid,
+                fitbit_userid=user.fitbit.fitbit_user_id,
                 slack_alias=user.slack_alias,
             ),
             oauth_data=OAuthFields(
-                oauth_userid=fitbit_userid,
+                oauth_userid=user.fitbit.oauth_userid,
                 oauth_access_token=user.fitbit.oauth_access_token,
                 oauth_refresh_token=user.fitbit.oauth_refresh_token,
                 oauth_expiration_date=user.fitbit.oauth_expiration_date.replace(
@@ -168,7 +172,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             )
             .where(
                 and_(
-                    models.FitbitUser.oauth_userid == fitbit_userid,
+                    models.FitbitUser.fitbit_user_id == fitbit_userid,
                     models.FitbitActivity.type_id == type_id,
                 )
             )
@@ -188,7 +192,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
                 .join(models.FitbitUser)
                 .where(
                     and_(
-                        models.FitbitUser.oauth_userid == fitbit_userid,
+                        models.FitbitUser.fitbit_user_id == fitbit_userid,
                         models.FitbitActivity.log_id == log_id,
                     )
                 )
@@ -204,7 +208,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         user: models.FitbitUser = (
             await self.db.scalars(
                 statement=select(models.FitbitUser).where(
-                    models.FitbitUser.oauth_userid == fitbit_userid
+                    models.FitbitUser.fitbit_user_id == fitbit_userid
                 )
             )
         ).one_or_none()
@@ -261,7 +265,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
     ):
         await self.db.execute(
             statement=update(models.FitbitUser)
-            .where(models.FitbitUser.oauth_userid == fitbit_userid)
+            .where(models.FitbitUser.fitbit_user_id == fitbit_userid)
             .values(
                 last_sleep_start_time=sleep.start_time,
                 last_sleep_end_time=sleep.end_time,
@@ -278,7 +282,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         fitbit_user: models.FitbitUser = (
             await self.db.scalars(
                 statement=select(models.FitbitUser).where(
-                    models.FitbitUser.oauth_userid == fitbit_userid
+                    models.FitbitUser.fitbit_user_id == fitbit_userid
                 )
             )
         ).one_or_none()
@@ -295,13 +299,14 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def update_oauth_data(
         self,
-        fitbit_userid: str,
+        oauth_userid: str,
         oauth_data: OAuthFields,
     ):
         await self.db.execute(
             statement=update(models.FitbitUser)
-            .where(models.FitbitUser.oauth_userid == fitbit_userid)
+            .where(models.FitbitUser.oauth_userid == oauth_userid)
             .values(
+                oauth_userid=oauth_data.oauth_userid,
                 oauth_access_token=oauth_data.oauth_access_token,
                 oauth_refresh_token=oauth_data.oauth_refresh_token,
                 oauth_expiration_date=oauth_data.oauth_expiration_date,
@@ -325,7 +330,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             models.FitbitActivity.peak_minutes,
         ]
         conditions = [
-            models.FitbitUser.oauth_userid == fitbit_userid,
+            models.FitbitUser.fitbit_user_id == fitbit_userid,
             models.FitbitActivity.type_id == type_id,
         ]
         if since:
@@ -371,7 +376,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
                 .where(
                     and_(
                         models.FitbitDailyActivity.date < activity_date,
-                        models.FitbitUser.oauth_userid == fitbit_userid,
+                        models.FitbitUser.fitbit_user_id == fitbit_userid,
                         models.FitbitDailyActivity.type_id == type_id,
                     )
                 )
@@ -382,7 +387,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             return None
         return DailyActivityStats(
             date=daily_activity.date,
-            fitbit_userid=daily_activity.fitbit_user.oauth_userid,
+            fitbit_userid=daily_activity.fitbit_user.fitbit_user_id,
             slack_alias=daily_activity.fitbit_user.user.slack_alias,
             type_id=daily_activity.type_id,
             count_activities=daily_activity.count_activities,
@@ -416,7 +421,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             .where(
                 and_(
                     models.FitbitDailyActivity.date == activity_date,
-                    models.FitbitUser.oauth_userid == fitbit_userid,
+                    models.FitbitUser.fitbit_user_id == fitbit_userid,
                     models.FitbitDailyActivity.type_id.in_(activity_type_ids),
                 )
             )
@@ -535,7 +540,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             .where(
                 and_(
                     models.FitbitDailyActivity.date <= up_to_date,
-                    models.FitbitUser.oauth_userid == fitbit_userid,
+                    models.FitbitUser.fitbit_user_id == fitbit_userid,
                     models.FitbitDailyActivity.type_id == primary_type_id,
                     yesterday_activity_alias.date
                     == None,  # noqa E711 (sqlalchemy needs this)
@@ -620,7 +625,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             .where(
                 and_(
                     models.FitbitDailyActivity.date <= up_to_date,
-                    models.FitbitUser.oauth_userid == fitbit_userid,
+                    models.FitbitUser.fitbit_user_id == fitbit_userid,
                     models.FitbitDailyActivity.type_id.in_(type_ids_filter),
                 )
             )
@@ -738,7 +743,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         return [
             DailyActivityStats(
                 date=daily_activity.date,
-                fitbit_userid=daily_activity.fitbit_user.oauth_userid,
+                fitbit_userid=daily_activity.fitbit_user.fitbit_user_id,
                 slack_alias=daily_activity.fitbit_user.user.slack_alias,
                 type_id=daily_activity.type_id,
                 count_activities=daily_activity.count_activities,
@@ -770,7 +775,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             models.FitbitDailyActivity.sum_out_of_zone_minutes,
         ]
         conditions = [
-            models.FitbitUser.oauth_userid == fitbit_userid,
+            models.FitbitUser.fitbit_user_id == fitbit_userid,
             models.FitbitDailyActivity.type_id == type_id,
         ]
         if since:

--- a/slackhealthbot/data/repositories/sqlalchemyfitbitrepository.py
+++ b/slackhealthbot/data/repositories/sqlalchemyfitbitrepository.py
@@ -22,6 +22,7 @@ from slackhealthbot.domain.models.activity import (
     TopDailyActivityStats,
 )
 from slackhealthbot.domain.models.sleep import SleepData
+from slackhealthbot.domain.models.users import UserLookup
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         self,
         slack_alias: str,
         fitbit_user_id: str | None,
+        health_user_id: str | None,
         oauth_data: OAuthFields,
     ) -> User:
         user = (
@@ -57,6 +59,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             oauth_refresh_token=oauth_data.oauth_refresh_token,
             oauth_expiration_date=oauth_data.oauth_expiration_date,
             fitbit_user_id=fitbit_user_id,
+            health_user_id=health_user_id,
         )
         self.db.add(fitbit_user)
         await self.db.commit()
@@ -65,6 +68,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         return User(
             identity=UserIdentity(
                 fitbit_userid=fitbit_user.fitbit_user_id,
+                health_user_id=fitbit_user.health_user_id,
                 slack_alias=slack_alias,
             ),
             oauth_data=OAuthFields(
@@ -77,20 +81,21 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             ),
         )
 
-    async def get_user_identity_by_fitbit_userid(
+    async def get_user_identity(
         self,
-        fitbit_userid: str,
+        user_lookup: models.UserLookup,
     ) -> UserIdentity | None:
         user: models.User = (
             await self.db.scalars(
                 statement=select(models.User)
                 .join(models.User.fitbit)
-                .where(models.FitbitUser.fitbit_user_id == fitbit_userid)
+                .where(_where_clause(user_lookup))
             )
         ).one_or_none()
         return (
             UserIdentity(
                 fitbit_userid=user.fitbit.fitbit_user_id,
+                health_user_id=user.fitbit.health_user_id,
                 slack_alias=user.slack_alias,
             )
             if user
@@ -106,20 +111,19 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         return [
             UserIdentity(
                 fitbit_userid=x.fitbit.fitbit_user_id,
+                health_user_id=x.fitbit.health_user_id,
                 slack_alias=x.slack_alias,
             )
             for x in users
         ]
 
-    async def get_oauth_data_by_fitbit_userid(
+    async def get_oauth_data_by_user_lookup(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
     ) -> OAuthFields:
         fitbit_user: models.FitbitUser = (
             await self.db.scalars(
-                statement=select(models.FitbitUser).where(
-                    models.FitbitUser.fitbit_user_id == fitbit_userid
-                )
+                statement=select(models.FitbitUser).where(_where_clause(user_lookup))
             )
         ).one()
         return OAuthFields(
@@ -131,15 +135,15 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             ),
         )
 
-    async def get_user_by_fitbit_userid(
+    async def get_user_by_lookup(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
     ) -> User:
         user: models.User = (
             await self.db.scalars(
                 statement=select(models.User)
                 .join(models.User.fitbit)
-                .where(models.FitbitUser.fitbit_user_id == fitbit_userid)
+                .where(_where_clause(user_lookup))
             )
         ).one_or_none()
         if not user:
@@ -147,6 +151,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         return User(
             identity=UserIdentity(
                 fitbit_userid=user.fitbit.fitbit_user_id,
+                health_user_id=user.fitbit.health_user_id,
                 slack_alias=user.slack_alias,
             ),
             oauth_data=OAuthFields(
@@ -161,7 +166,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def get_latest_activity_by_user_and_type(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         type_id: int,
     ) -> ActivityData | None:
         db_activity: models.FitbitActivity = await self.db.scalar(
@@ -172,7 +177,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             )
             .where(
                 and_(
-                    models.FitbitUser.fitbit_user_id == fitbit_userid,
+                    _where_clause(user_lookup),
                     models.FitbitActivity.type_id == type_id,
                 )
             )
@@ -183,7 +188,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def get_activity_by_user_and_log_id(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         log_id: str,
     ) -> ActivityData | None:
         db_activity: models.FitbitActivity = (
@@ -192,7 +197,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
                 .join(models.FitbitUser)
                 .where(
                     and_(
-                        models.FitbitUser.fitbit_user_id == fitbit_userid,
+                        _where_clause(user_lookup),
                         models.FitbitActivity.log_id == log_id,
                     )
                 )
@@ -202,14 +207,12 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def upsert_activity_for_user(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         activity: ActivityData,
     ) -> bool:
         user: models.FitbitUser = (
             await self.db.scalars(
-                statement=select(models.FitbitUser).where(
-                    models.FitbitUser.fitbit_user_id == fitbit_userid
-                )
+                statement=select(models.FitbitUser).where(_where_clause(user_lookup))
             )
         ).one_or_none()
         if not user:
@@ -260,12 +263,12 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def update_sleep_for_user(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         sleep: SleepData,
     ):
         await self.db.execute(
             statement=update(models.FitbitUser)
-            .where(models.FitbitUser.fitbit_user_id == fitbit_userid)
+            .where(_where_clause(user_lookup))
             .values(
                 last_sleep_start_time=sleep.start_time,
                 last_sleep_end_time=sleep.end_time,
@@ -275,15 +278,13 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         )
         await self.db.commit()
 
-    async def get_sleep_by_fitbit_userid(
+    async def get_sleep_by_user_lookup(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
     ) -> SleepData | None:
         fitbit_user: models.FitbitUser = (
             await self.db.scalars(
-                statement=select(models.FitbitUser).where(
-                    models.FitbitUser.fitbit_user_id == fitbit_userid
-                )
+                statement=select(models.FitbitUser).where(_where_clause(user_lookup))
             )
         ).one_or_none()
         if not fitbit_user:
@@ -314,9 +315,42 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         )
         await self.db.commit()
 
+    async def update_oauth_data_by_fitbit_user_id(
+        self,
+        fitbit_user_id: str,
+        oauth_data: OAuthFields,
+    ):
+        await self.db.execute(
+            statement=update(models.FitbitUser)
+            .where(models.FitbitUser.fitbit_user_id == fitbit_user_id)
+            .values(
+                oauth_userid=oauth_data.oauth_userid,
+                oauth_access_token=oauth_data.oauth_access_token,
+                oauth_refresh_token=oauth_data.oauth_refresh_token,
+                oauth_expiration_date=oauth_data.oauth_expiration_date,
+            )
+        )
+        await self.db.commit()
+
+    async def update_user_ids(
+        self,
+        oauth_userid: str,
+        fitbit_user_id: str | None,
+        health_user_id: str | None,
+    ):
+        await self.db.execute(
+            statement=update(models.FitbitUser)
+            .where(models.FitbitUser.oauth_userid == oauth_userid)
+            .values(
+                fitbit_user_id=fitbit_user_id,
+                health_user_id=health_user_id,
+            )
+        )
+        await self.db.commit()
+
     async def get_top_activity_stats_by_user_and_activity_type(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         type_id: int,
         since: datetime.datetime | None = None,
     ) -> TopActivityStats:
@@ -330,7 +364,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             models.FitbitActivity.peak_minutes,
         ]
         conditions = [
-            models.FitbitUser.fitbit_user_id == fitbit_userid,
+            _where_clause(user_lookup),
             models.FitbitActivity.type_id == type_id,
         ]
         if since:
@@ -363,7 +397,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def get_latest_daily_activity_by_user_and_activity_type(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         type_id: int,
         before: datetime.date | None = None,
     ) -> DailyActivityStats | None:
@@ -376,7 +410,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
                 .where(
                     and_(
                         models.FitbitDailyActivity.date < activity_date,
-                        models.FitbitUser.fitbit_user_id == fitbit_userid,
+                        _where_clause(user_lookup),
                         models.FitbitDailyActivity.type_id == type_id,
                     )
                 )
@@ -387,7 +421,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             return None
         return DailyActivityStats(
             date=daily_activity.date,
-            fitbit_userid=daily_activity.fitbit_user.fitbit_user_id,
+            user_lookup=daily_activity.fitbit_user.lookup,
             slack_alias=daily_activity.fitbit_user.user.slack_alias,
             type_id=daily_activity.type_id,
             count_activities=daily_activity.count_activities,
@@ -402,7 +436,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def get_daily_activity_streak_days_count_for_user_and_activity_type(  # noqa: PLR0913
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         primary_type_id: int,
         *,
         secondary_type_id: int | None = None,
@@ -421,7 +455,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             .where(
                 and_(
                     models.FitbitDailyActivity.date == activity_date,
-                    models.FitbitUser.fitbit_user_id == fitbit_userid,
+                    _where_clause(user_lookup),
                     models.FitbitDailyActivity.type_id.in_(activity_type_ids),
                 )
             )
@@ -438,7 +472,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
         if days_without_activies_break_streak:
             return await self._calculate_streak_strict_mode(
-                fitbit_userid=fitbit_userid,
+                user_lookup=user_lookup,
                 primary_type_id=primary_type_id,
                 secondary_type_id=secondary_type_id,
                 up_to_date=activity_date,
@@ -446,7 +480,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             )
 
         return await self._calculate_streak_lax_mode(
-            fitbit_userid=fitbit_userid,
+            user_lookup=user_lookup,
             primary_type_id=primary_type_id,
             secondary_type_id=secondary_type_id,
             up_to_date=activity_date,
@@ -455,14 +489,14 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def _calculate_streak_strict_mode(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         primary_type_id: int,
         secondary_type_id: int | None,
         up_to_date: datetime.date,
         min_distance_km: float | None,
     ):
         logger.info(
-            f"Calculate streak strict mode for {fitbit_userid}, primary {primary_type_id}, secondary {secondary_type_id}, up to date {up_to_date}, min distance km {min_distance_km}"
+            f"Calculate streak strict mode for {user_lookup}, primary {primary_type_id}, secondary {secondary_type_id}, up to date {up_to_date}, min distance km {min_distance_km}"
         )
         today_filters = []
         yesterday_filters = []
@@ -540,7 +574,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             .where(
                 and_(
                     models.FitbitDailyActivity.date <= up_to_date,
-                    models.FitbitUser.fitbit_user_id == fitbit_userid,
+                    _where_clause(user_lookup),
                     models.FitbitDailyActivity.type_id == primary_type_id,
                     yesterday_activity_alias.date
                     == None,  # noqa E711 (sqlalchemy needs this)
@@ -574,14 +608,14 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def _calculate_streak_lax_mode(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         primary_type_id: int,
         secondary_type_id: int | None,
         up_to_date: datetime.date,
         min_distance_km: float | None,
     ):
         logger.info(
-            f"Calculate streak lax mode for {fitbit_userid}, primary {primary_type_id}, secondary {secondary_type_id}, up to date {up_to_date}, min distance km {min_distance_km}"
+            f"Calculate streak lax mode for {user_lookup}, primary {primary_type_id}, secondary {secondary_type_id}, up to date {up_to_date}, min distance km {min_distance_km}"
         )
         # Filter on rows with either the primary or secondary type id
         type_ids_filter = [primary_type_id]
@@ -625,7 +659,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             .where(
                 and_(
                     models.FitbitDailyActivity.date <= up_to_date,
-                    models.FitbitUser.fitbit_user_id == fitbit_userid,
+                    _where_clause(user_lookup),
                     models.FitbitDailyActivity.type_id.in_(type_ids_filter),
                 )
             )
@@ -743,7 +777,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
         return [
             DailyActivityStats(
                 date=daily_activity.date,
-                fitbit_userid=daily_activity.fitbit_user.fitbit_user_id,
+                user_lookup=daily_activity.fitbit_user.lookup,
                 slack_alias=daily_activity.fitbit_user.user.slack_alias,
                 type_id=daily_activity.type_id,
                 count_activities=daily_activity.count_activities,
@@ -760,7 +794,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
 
     async def get_top_daily_activity_stats_by_user_and_activity_type(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         type_id: int,
         since: datetime.datetime | None = None,
     ) -> TopActivityStats:
@@ -775,7 +809,7 @@ class SQLAlchemyFitbitRepository(LocalFitbitRepository):
             models.FitbitDailyActivity.sum_out_of_zone_minutes,
         ]
         conditions = [
-            models.FitbitUser.fitbit_user_id == fitbit_userid,
+            _where_clause(user_lookup),
             models.FitbitDailyActivity.type_id == type_id,
         ]
         if since:
@@ -815,3 +849,11 @@ def _db_activity_to_domain_activity(
             if getattr(db_activity, f"{x}_minutes")
         ],
     )
+
+
+def _where_clause(user_lookup: UserLookup):
+    match user_lookup:
+        case models.FitbitUserLookup(user_id):
+            return models.FitbitUser.fitbit_user_id == user_id
+        case models.HealthUserLookup(user_id):
+            return models.FitbitUser.health_user_id == user_id

--- a/slackhealthbot/domain/localrepository/localfitbitrepository.py
+++ b/slackhealthbot/domain/localrepository/localfitbitrepository.py
@@ -9,12 +9,24 @@ from slackhealthbot.domain.models.activity import (
     TopActivityStats,
 )
 from slackhealthbot.domain.models.sleep import SleepData
+from slackhealthbot.domain.models.users import (
+    FitbitUserLookup,
+    HealthUserLookup,
+    UserLookup,
+)
 
 
 @dataclasses.dataclass
 class UserIdentity:
-    fitbit_userid: str
+    fitbit_userid: str | None
+    health_user_id: str | None
     slack_alias: str
+
+    @property
+    def user_lookup(self) -> UserLookup:
+        if self.health_user_id:
+            return HealthUserLookup(user_id=self.health_user_id)
+        return FitbitUserLookup(user_id=self.fitbit_userid)
 
 
 @dataclasses.dataclass
@@ -28,40 +40,39 @@ class LocalFitbitRepository(ABC):
     async def create_user(
         self,
         slack_alias: str,
-        fitbit_userid: str,
+        fitbit_user_id: str | None,
+        health_user_id: str | None,
         oauth_data: OAuthFields,
     ) -> User:
         pass
 
     @abstractmethod
-    async def get_user_identity_by_fitbit_userid(
+    async def get_user_identity(
         self,
-        fitbit_userid: str,
-    ) -> UserIdentity | None:
-        pass
+        user_lookup: UserLookup,
+    ) -> UserIdentity | None: ...
 
     @abstractmethod
     async def get_all_user_identities(self) -> list[UserIdentity]:
         pass
 
     @abstractmethod
-    async def get_oauth_data_by_fitbit_userid(
+    async def get_oauth_data_by_user_lookup(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
     ) -> OAuthFields:
         pass
 
     @abstractmethod
-    async def get_user_by_fitbit_userid(
+    async def get_user_by_lookup(
         self,
-        fitbit_userid: str,
-    ) -> User:
-        pass
+        user_lookup: UserLookup,
+    ) -> User: ...
 
     @abstractmethod
     async def get_latest_activity_by_user_and_type(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         type_id: int,
     ) -> ActivityData | None:
         pass
@@ -69,7 +80,7 @@ class LocalFitbitRepository(ABC):
     @abstractmethod
     async def get_activity_by_user_and_log_id(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         log_id: str,
     ) -> ActivityData | None:
         pass
@@ -77,7 +88,7 @@ class LocalFitbitRepository(ABC):
     @abstractmethod
     async def upsert_activity_for_user(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         activity: ActivityData,
     ) -> bool:
         """
@@ -88,17 +99,15 @@ class LocalFitbitRepository(ABC):
     @abstractmethod
     async def update_sleep_for_user(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         sleep: SleepData,
     ):
         pass
 
-    @abstractmethod
-    async def get_sleep_by_fitbit_userid(
+    async def get_sleep_by_user_lookup(
         self,
-        fitbit_userid: str,
-    ) -> SleepData | None:
-        pass
+        user_lookup: UserLookup,
+    ) -> SleepData | None: ...
 
     @abstractmethod
     async def update_oauth_data(
@@ -109,9 +118,21 @@ class LocalFitbitRepository(ABC):
         pass
 
     @abstractmethod
+    async def update_oauth_data_by_fitbit_user_id(
+        self,
+        fitbit_user_id: str,
+        oauth_data: OAuthFields,
+    ): ...
+
+    @abstractmethod
+    async def update_user_ids(
+        self, oauth_userid: str, fitbit_user_id: str | None, health_user_id: str | None
+    ): ...
+
+    @abstractmethod
     async def get_top_activity_stats_by_user_and_activity_type(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         type_id: int,
         since: datetime.datetime | None = None,
     ) -> TopActivityStats:
@@ -120,7 +141,7 @@ class LocalFitbitRepository(ABC):
     @abstractmethod
     async def get_latest_daily_activity_by_user_and_activity_type(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         primary_type_id: int,
         secondary_type_id: int | None = None,
         before: datetime.date | None = None,
@@ -134,7 +155,7 @@ class LocalFitbitRepository(ABC):
     @abstractmethod
     async def get_daily_activity_streak_days_count_for_user_and_activity_type(  # noqa: PLR0913
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         primary_type_id: int,
         *,
         secondary_type_id: int | None = None,
@@ -182,7 +203,7 @@ class LocalFitbitRepository(ABC):
     @abstractmethod
     async def get_top_daily_activity_stats_by_user_and_activity_type(
         self,
-        fitbit_userid: str,
+        user_lookup: UserLookup,
         type_id: int,
         since: datetime.datetime | None = None,
     ) -> TopActivityStats:

--- a/slackhealthbot/domain/localrepository/localfitbitrepository.py
+++ b/slackhealthbot/domain/localrepository/localfitbitrepository.py
@@ -103,7 +103,7 @@ class LocalFitbitRepository(ABC):
     @abstractmethod
     async def update_oauth_data(
         self,
-        fitbit_userid: str,
+        oauth_userid: str,
         oauth_data: OAuthFields,
     ):
         pass

--- a/slackhealthbot/domain/models/activity.py
+++ b/slackhealthbot/domain/models/activity.py
@@ -2,6 +2,8 @@ import dataclasses
 import datetime as dt
 from enum import StrEnum, auto
 
+from slackhealthbot.domain.models.users import UserLookup
+
 
 class ActivityZone(StrEnum):
     PEAK = auto()
@@ -45,7 +47,7 @@ class ActivityHistory:
 @dataclasses.dataclass
 class DailyActivityStats:
     date: dt.date
-    fitbit_userid: int
+    user_lookup: UserLookup
     slack_alias: str
     type_id: int
     count_activities: int

--- a/slackhealthbot/domain/models/users.py
+++ b/slackhealthbot/domain/models/users.py
@@ -1,0 +1,15 @@
+import dataclasses
+from typing import TypeAlias
+
+
+@dataclasses.dataclass(frozen=True)
+class FitbitUserLookup:
+    user_id: str
+
+
+@dataclasses.dataclass(frozen=True)
+class HealthUserLookup:
+    user_id: str
+
+
+UserLookup: TypeAlias = FitbitUserLookup | HealthUserLookup

--- a/slackhealthbot/domain/usecases/fitbit/usecase_calculate_streak.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_calculate_streak.py
@@ -30,7 +30,6 @@ async def do(
 
     If we have a goal and we didn't meet it at the given date, there's no streak: return None.
     """
-    fitbit_userid = daily_activity.fitbit_userid
     report_settings = settings.app_settings.fitbit.activities.get_report(
         activity_type_id=daily_activity.type_id
     )
@@ -40,7 +39,7 @@ async def do(
 
     # Return the number of days since the first day in the streak, including the given end_date.
     return await local_fitbit_repo.get_daily_activity_streak_days_count_for_user_and_activity_type(
-        fitbit_userid=fitbit_userid,
+        user_lookup=daily_activity.user_lookup,
         primary_type_id=daily_activity.type_id,
         secondary_type_id=report_settings.streak.secondary_activity_type_id,
         before=end_date,

--- a/slackhealthbot/domain/usecases/fitbit/usecase_get_last_sleep.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_get_last_sleep.py
@@ -8,6 +8,7 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
     LocalFitbitRepository,
 )
 from slackhealthbot.domain.models.sleep import SleepData
+from slackhealthbot.domain.models.users import UserLookup
 from slackhealthbot.domain.remoterepository.remotefitbitrepository import (
     RemoteFitbitRepository,
 )
@@ -15,13 +16,13 @@ from slackhealthbot.domain.remoterepository.remotefitbitrepository import (
 
 @inject
 async def do(
-    fitbit_userid: str,
+    user_lookup: UserLookup,
     when: datetime.date,
     local_repo: LocalFitbitRepository = Provide[Container.local_fitbit_repository],
     remote_repo: RemoteFitbitRepository = Provide[Container.remote_fitbit_repository],
 ) -> SleepData | None:
-    oauth_data: OAuthFields = await local_repo.get_oauth_data_by_fitbit_userid(
-        fitbit_userid=fitbit_userid,
+    oauth_data: OAuthFields = await local_repo.get_oauth_data_by_user_lookup(
+        user_lookup
     )
     return await remote_repo.get_sleep(
         oauth_fields=oauth_data,

--- a/slackhealthbot/domain/usecases/fitbit/usecase_login_user.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_login_user.py
@@ -9,6 +9,7 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
     User,
     UserIdentity,
 )
+from slackhealthbot.domain.models.users import FitbitUserLookup
 from slackhealthbot.domain.remoterepository.remotefitbitrepository import (
     RemoteFitbitRepository,
 )
@@ -32,20 +33,26 @@ async def _upsert_user(
     token: dict[str, Any],
 ) -> User:
     oauth_fields: OAuthFields = remote_repo.parse_oauth_fields(token)
-    user_identity: UserIdentity = await local_repo.get_user_identity_by_fitbit_userid(
-        fitbit_userid=oauth_fields.oauth_userid
+    user_identity: UserIdentity = await local_repo.get_user_identity(
+        FitbitUserLookup(user_id=oauth_fields.oauth_userid)
     )
     if not user_identity:
         return await local_repo.create_user(
             slack_alias=slack_alias,
             fitbit_user_id=oauth_fields.oauth_userid,
+            health_user_id=None,
             oauth_data=oauth_fields,
         )
     else:
-        await local_repo.update_oauth_data(
-            oauth_userid=oauth_fields.oauth_userid,
+        await local_repo.update_oauth_data_by_fitbit_user_id(
+            fitbit_user_id=oauth_fields.oauth_userid,
             oauth_data=oauth_fields,
         )
-    return await local_repo.get_user_by_fitbit_userid(
-        fitbit_userid=oauth_fields.oauth_userid,
+        await local_repo.update_user_ids(
+            oauth_userid=oauth_fields.oauth_userid,
+            fitbit_user_id=oauth_fields.oauth_userid,
+            health_user_id=None,
+        )
+    return await local_repo.get_user_by_lookup(
+        FitbitUserLookup(user_id=oauth_fields.oauth_userid),
     )

--- a/slackhealthbot/domain/usecases/fitbit/usecase_login_user.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_login_user.py
@@ -38,12 +38,12 @@ async def _upsert_user(
     if not user_identity:
         return await local_repo.create_user(
             slack_alias=slack_alias,
-            fitbit_userid=oauth_fields.oauth_userid,
+            fitbit_user_id=oauth_fields.oauth_userid,
             oauth_data=oauth_fields,
         )
     else:
         await local_repo.update_oauth_data(
-            fitbit_userid=oauth_fields.oauth_userid,
+            oauth_userid=oauth_fields.oauth_userid,
             oauth_data=oauth_fields,
         )
     return await local_repo.get_user_by_fitbit_userid(

--- a/slackhealthbot/domain/usecases/fitbit/usecase_post_user_logged_out.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_post_user_logged_out.py
@@ -5,6 +5,7 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
     LocalFitbitRepository,
     UserIdentity,
 )
+from slackhealthbot.domain.models.users import HealthUserLookup, UserLookup
 from slackhealthbot.domain.usecases.slack import (
     usecase_post_user_logged_out as slack_usecase_post_user_logged_out,
 )
@@ -12,13 +13,12 @@ from slackhealthbot.domain.usecases.slack import (
 
 @inject
 async def do(
-    fitbit_userid: str,
+    user_lookup: UserLookup,
     fitbit_repo: LocalFitbitRepository = Provide[Container.local_fitbit_repository],
 ):
-    user_identity: UserIdentity = await fitbit_repo.get_user_identity_by_fitbit_userid(
-        fitbit_userid=fitbit_userid,
-    )
+    service = "google" if isinstance(user_lookup, HealthUserLookup) else "fitbit"
+    user_identity: UserIdentity = await fitbit_repo.get_user_identity(user_lookup)
     await slack_usecase_post_user_logged_out.do(
         slack_alias=user_identity.slack_alias,
-        service="fitbit",
+        service=service,
     )

--- a/slackhealthbot/domain/usecases/fitbit/usecase_process_daily_activity.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_process_daily_activity.py
@@ -26,34 +26,31 @@ async def do(
     ],
 ):
     now = dt.datetime.now(dt.timezone.utc)
-    fitbit_userid = daily_activity.fitbit_userid
     streak_distance_km_days = await usecase_calculate_streak.do(
         local_fitbit_repo=local_fitbit_repo,
         daily_activity=daily_activity,
         end_date=now.date(),
     )
 
-    user_identity: UserIdentity = (
-        await local_fitbit_repo.get_user_identity_by_fitbit_userid(
-            fitbit_userid=fitbit_userid
-        )
+    user_identity: UserIdentity = await local_fitbit_repo.get_user_identity(
+        daily_activity.user_lookup,
     )
     previous_daily_activity_stats: DailyActivityStats = (
         await local_fitbit_repo.get_latest_daily_activity_by_user_and_activity_type(
-            fitbit_userid=fitbit_userid,
+            user_lookup=daily_activity.user_lookup,
             type_id=daily_activity.type_id,
             before=now.date(),
         )
     )
     all_time_top_daily_activity_stats: TopActivityStats = (
         await local_fitbit_repo.get_top_daily_activity_stats_by_user_and_activity_type(
-            fitbit_userid=fitbit_userid,
+            user_lookup=daily_activity.user_lookup,
             type_id=daily_activity.type_id,
         )
     )
     recent_top_daily_activity_stats: TopActivityStats = (
         await local_fitbit_repo.get_top_daily_activity_stats_by_user_and_activity_type(
-            fitbit_userid=fitbit_userid,
+            user_lookup=daily_activity.user_lookup,
             type_id=daily_activity.type_id,
             since=now
             - dt.timedelta(days=settings.app_settings.fitbit.activities.history_days),

--- a/slackhealthbot/domain/usecases/fitbit/usecase_process_new_activity.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_process_new_activity.py
@@ -5,6 +5,7 @@ from dependency_injector.wiring import Provide, inject
 from slackhealthbot.containers import Container
 from slackhealthbot.domain.localrepository.localfitbitrepository import (
     LocalFitbitRepository,
+    User,
     UserIdentity,
 )
 from slackhealthbot.domain.models.activity import (
@@ -12,6 +13,7 @@ from slackhealthbot.domain.models.activity import (
     ActivityHistory,
     TopActivityStats,
 )
+from slackhealthbot.domain.models.users import UserLookup
 from slackhealthbot.domain.remoterepository.remotefitbitrepository import (
     RemoteFitbitRepository,
 )
@@ -21,7 +23,7 @@ from slackhealthbot.settings import Settings
 
 @inject
 async def do(  # noqa: PLR0913 deal with this later
-    fitbit_userid: str,
+    user_lookup: UserLookup,
     when: datetime.date,
     settings: Settings = Provide[Container.settings],
     local_fitbit_repo: LocalFitbitRepository = Provide[
@@ -31,14 +33,8 @@ async def do(  # noqa: PLR0913 deal with this later
         Container.remote_fitbit_repository
     ],
 ) -> list[ActivityData]:
-    user_identity: UserIdentity = (
-        await local_fitbit_repo.get_user_identity_by_fitbit_userid(
-            fitbit_userid=fitbit_userid,
-        )
-    )
-    user = await local_fitbit_repo.get_user_by_fitbit_userid(
-        fitbit_userid=fitbit_userid,
-    )
+    user_identity: UserIdentity = await local_fitbit_repo.get_user_identity(user_lookup)
+    user: User = await local_fitbit_repo.get_user_by_lookup(user_lookup)
     activities = await remote_fitbit_repo.get_activities_for_date(
         oauth_fields=user.oauth_data,
         when=when,
@@ -58,7 +54,7 @@ async def do(  # noqa: PLR0913 deal with this later
             continue
 
         created = await local_fitbit_repo.upsert_activity_for_user(
-            fitbit_userid=fitbit_userid,
+            user_lookup=user_lookup,
             activity=new_activity_data,
         )
         if not created:
@@ -73,13 +69,13 @@ async def do(  # noqa: PLR0913 deal with this later
 
         all_time_top_activity_stats: TopActivityStats = (
             await local_fitbit_repo.get_top_activity_stats_by_user_and_activity_type(
-                fitbit_userid=fitbit_userid,
+                user_lookup=user_lookup,
                 type_id=new_activity_data.type_id,
             )
         )
         recent_top_activity_stats: TopActivityStats = (
             await local_fitbit_repo.get_top_activity_stats_by_user_and_activity_type(
-                fitbit_userid=fitbit_userid,
+                user_lookup=user_lookup,
                 type_id=new_activity_data.type_id,
                 since=recent_since,
             )

--- a/slackhealthbot/domain/usecases/fitbit/usecase_process_new_sleep.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_process_new_sleep.py
@@ -8,35 +8,32 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
     UserIdentity,
 )
 from slackhealthbot.domain.models.sleep import SleepData
+from slackhealthbot.domain.models.users import UserLookup
 from slackhealthbot.domain.usecases.fitbit import usecase_get_last_sleep
 from slackhealthbot.domain.usecases.slack import usecase_post_sleep
 
 
 @inject
 async def do(
-    fitbit_userid: str,
+    user_lookup: UserLookup,
     when: datetime.date,
     local_fitbit_repo: LocalFitbitRepository = Provide[
         Container.local_fitbit_repository
     ],
 ) -> SleepData | None:
-    user_identity: UserIdentity = (
-        await local_fitbit_repo.get_user_identity_by_fitbit_userid(
-            fitbit_userid=fitbit_userid,
-        )
-    )
-    last_sleep_data: SleepData = await local_fitbit_repo.get_sleep_by_fitbit_userid(
-        fitbit_userid=fitbit_userid,
+    user_identity: UserIdentity = await local_fitbit_repo.get_user_identity(user_lookup)
+    last_sleep_data: SleepData = await local_fitbit_repo.get_sleep_by_user_lookup(
+        user_lookup
     )
     new_sleep_data: SleepData = await usecase_get_last_sleep.do(
         local_repo=local_fitbit_repo,
-        fitbit_userid=fitbit_userid,
+        user_lookup=user_lookup,
         when=when,
     )
     if not new_sleep_data:
         return None
     await local_fitbit_repo.update_sleep_for_user(
-        fitbit_userid=fitbit_userid,
+        user_lookup=user_lookup,
         sleep=new_sleep_data,
     )
     if last_sleep_data is None or last_sleep_data.end_time != new_sleep_data.end_time:

--- a/slackhealthbot/domain/usecases/fitbit/usecase_update_user_oauth.py
+++ b/slackhealthbot/domain/usecases/fitbit/usecase_update_user_oauth.py
@@ -32,6 +32,6 @@ class UpdateTokenUseCase(Callable):
     ):
         oauth_fields: OAuthFields = self.remote_repo.parse_oauth_fields(token)
         await local_repo.update_oauth_data(
-            fitbit_userid=oauth_fields.oauth_userid,
+            oauth_userid=oauth_fields.oauth_userid,
             oauth_data=oauth_fields,
         )

--- a/slackhealthbot/routers/fitbit.py
+++ b/slackhealthbot/routers/fitbit.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from slackhealthbot.containers import Container
 from slackhealthbot.core.exceptions import UnknownUserException, UserLoggedOutException
+from slackhealthbot.domain.models.users import FitbitUserLookup
 from slackhealthbot.domain.usecases.fitbit import (
     usecase_login_user,
     usecase_post_user_logged_out,
@@ -117,21 +118,21 @@ async def fitbit_notification_webhook(
             try:
                 if notification.collectionType == "sleep":
                     new_sleep_data = await usecase_process_new_sleep.do(
-                        fitbit_userid=notification.ownerId,
+                        user_lookup=FitbitUserLookup(user_id=notification.ownerId),
                         when=notification.date,
                     )
                     if new_sleep_data:
                         _mark_fitbit_notification_processed(notification)
                 elif notification.collectionType == "activities":
                     activity_history = await usecase_process_new_activity.do(
-                        fitbit_userid=notification.ownerId,
+                        user_lookup=FitbitUserLookup(user_id=notification.ownerId),
                         when=notification.date or datetime.date.today(),
                     )
                     if activity_history:
                         _mark_fitbit_notification_processed(notification)
             except UserLoggedOutException:
                 await usecase_post_user_logged_out.do(
-                    fitbit_userid=notification.ownerId,
+                    FitbitUserLookup(user_id=notification.ownerId),
                 )
                 break
             except UnknownUserException:

--- a/slackhealthbot/tasks/fitbitpoll.py
+++ b/slackhealthbot/tasks/fitbitpoll.py
@@ -11,6 +11,7 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
     LocalFitbitRepository,
     UserIdentity,
 )
+from slackhealthbot.domain.models.users import HealthUserLookup, UserLookup
 from slackhealthbot.domain.usecases.fitbit import (
     usecase_process_new_activity,
     usecase_process_new_sleep,
@@ -21,34 +22,37 @@ from slackhealthbot.settings import Settings
 
 @dataclasses.dataclass
 class Cache:
-    cache_sleep_success: dict[str, datetime.date] = dataclasses.field(
+    cache_sleep_success: dict[UserLookup, datetime.date] = dataclasses.field(
         default_factory=dict
     )
-    cache_fail: dict[str, datetime.date] = dataclasses.field(default_factory=dict)
+    cache_fail: dict[UserLookup, datetime.date] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 async def handle_success_poll(
-    fitbit_userid: str,
+    user_lookup: UserLookup,
     when: datetime.date,
     cache: Cache,
 ):
-    cache.cache_sleep_success[fitbit_userid] = when
-    cache.cache_fail.pop(fitbit_userid, None)
+    cache.cache_sleep_success[user_lookup] = when
+    cache.cache_fail.pop(user_lookup, None)
 
 
 async def handle_fail_poll(
-    fitbit_userid: str,
+    user_lookup: UserLookup,
     slack_alias: str,
     when: datetime.date,
     cache: Cache,
 ):
-    last_error_post = cache.cache_fail.get(fitbit_userid)
+    service = "google" if isinstance(user_lookup, HealthUserLookup) else "fitbit"
+    last_error_post = cache.cache_fail.get(user_lookup)
     if not last_error_post or last_error_post < when:
         await usecase_post_user_logged_out.do(
             slack_alias=slack_alias,
-            service="fitbit",
+            service=service,
         )
-        cache.cache_fail[fitbit_userid] = when
+        cache.cache_fail[user_lookup] = when
 
 
 async def fitbit_poll(
@@ -105,12 +109,12 @@ async def fitbit_poll_activity(
 ):
     try:
         await usecase_process_new_activity.do(
-            fitbit_userid=poll_target.user_identity.fitbit_userid,
+            user_lookup=poll_target.user_identity.user_lookup,
             when=poll_target.when,
         )
     except UserLoggedOutException:
         await handle_fail_poll(
-            fitbit_userid=poll_target.user_identity.fitbit_userid,
+            user_lookup=poll_target.user_identity.user_lookup,
             slack_alias=poll_target.user_identity.slack_alias,
             when=poll_target.when,
             cache=cache,
@@ -122,17 +126,17 @@ async def fitbit_poll_sleep(
     poll_target: PollTarget,
 ):
     latest_successful_poll = cache.cache_sleep_success.get(
-        poll_target.user_identity.fitbit_userid
+        poll_target.user_identity.user_lookup
     )
     if not latest_successful_poll or latest_successful_poll < poll_target.when:
         try:
             sleep_data = await usecase_process_new_sleep.do(
-                fitbit_userid=poll_target.user_identity.fitbit_userid,
+                user_lookup=poll_target.user_identity.user_lookup,
                 when=poll_target.when,
             )
         except UserLoggedOutException:
             await handle_fail_poll(
-                fitbit_userid=poll_target.user_identity.fitbit_userid,
+                user_lookup=poll_target.user_identity.user_lookup,
                 slack_alias=poll_target.user_identity.slack_alias,
                 when=poll_target.when,
                 cache=cache,
@@ -140,7 +144,7 @@ async def fitbit_poll_sleep(
         else:
             if sleep_data:
                 await handle_success_poll(
-                    fitbit_userid=poll_target.user_identity.fitbit_userid,
+                    user_lookup=poll_target.user_identity.user_lookup,
                     when=poll_target.when,
                     cache=cache,
                 )

--- a/tests/data/repositories/test_fitbitrepository.py
+++ b/tests/data/repositories/test_fitbitrepository.py
@@ -132,7 +132,7 @@ async def test_top_activities(
 
     all_time_top_activity_stats: TopActivityStats = (
         await local_fitbit_repository.get_top_activity_stats_by_user_and_activity_type(
-            fitbit_userid=user.fitbit.oauth_userid,
+            user_lookup=user.fitbit.lookup,
             type_id=activity_type,
         )
     )
@@ -158,7 +158,7 @@ async def test_top_activities(
 
     recent_top_activity_stats: TopActivityStats = (
         await local_fitbit_repository.get_top_activity_stats_by_user_and_activity_type(
-            fitbit_userid=user.fitbit.oauth_userid,
+            user_lookup=user.fitbit.lookup,
             type_id=activity_type,
             since=recent_date - datetime.timedelta(days=1),
         )
@@ -196,7 +196,7 @@ async def test_top_activities_no_history(
 
     all_time_top_activity_stats: TopActivityStats = (
         await local_fitbit_repository.get_top_activity_stats_by_user_and_activity_type(
-            fitbit_userid=user.fitbit.oauth_userid,
+            user_lookup=user.fitbit.lookup,
             type_id=activity_type,
         )
     )
@@ -209,7 +209,7 @@ async def test_top_activities_no_history(
 
     recent_top_activity_stats: TopActivityStats = (
         await local_fitbit_repository.get_top_activity_stats_by_user_and_activity_type(
-            fitbit_userid=user.fitbit.oauth_userid,
+            user_lookup=user.fitbit.lookup,
             type_id=activity_type,
             since=recent_date - datetime.timedelta(days=1),
         )
@@ -268,7 +268,7 @@ async def test_daily_activities_one_entry(
     expected_daily_activity_stats = [
         DailyActivityStats(
             date=datetime.date(2024, 1, 2),
-            fitbit_userid=user.fitbit.oauth_userid,
+            user_lookup=user.fitbit.lookup,
             slack_alias="jondoe",
             type_id=1234,
             count_activities=2,
@@ -380,7 +380,7 @@ async def test_daily_activities_multiple_entries(
     # Get the list of daily activity stats just one user and activity type.
     actual_daily_activity_stats_one_user_and_type: DailyActivityStats = (
         await local_fitbit_repository.get_latest_daily_activity_by_user_and_activity_type(
-            fitbit_userid=user1.fitbit.oauth_userid,
+            user_lookup=user1.fitbit.lookup,
             type_id=1235,
             before=datetime.date(2024, 1, 4),
         )
@@ -398,7 +398,7 @@ async def test_daily_activities_multiple_entries(
     # Get the list of daily activity stats just one user and activity type, with no match.
     actual_daily_activity_stats_one_user_and_type: DailyActivityStats = (
         await local_fitbit_repository.get_latest_daily_activity_by_user_and_activity_type(
-            fitbit_userid=user1.fitbit.oauth_userid,
+            user_lookup=user1.fitbit.lookup,
             type_id=1235,
             before=datetime.date(2024, 1, 2),
         )
@@ -511,7 +511,7 @@ async def test_top_daily_activities(
 
     actual_top_daily_activities_all_time: TopDailyActivityStats = (
         await local_fitbit_repository.get_top_daily_activity_stats_by_user_and_activity_type(
-            fitbit_userid=user.fitbit.oauth_userid,
+            user_lookup=user.fitbit.lookup,
             type_id=activity_type,
         )
     )
@@ -530,7 +530,7 @@ async def test_top_daily_activities(
 
     actual_top_daily_activities_recent_times: TopActivityStats = (
         await local_fitbit_repository.get_top_daily_activity_stats_by_user_and_activity_type(
-            fitbit_userid=user.fitbit.oauth_userid,
+            user_lookup=user.fitbit.lookup,
             type_id=activity_type,
             since=recent_date - datetime.timedelta(days=1),
         )

--- a/tests/routes/test_fitbit_oauth.py
+++ b/tests/routes/test_fitbit_oauth.py
@@ -17,6 +17,7 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
     UserIdentity,
 )
 from slackhealthbot.domain.models.activity import ActivityData
+from slackhealthbot.domain.models.users import FitbitUserLookup
 from slackhealthbot.settings import Settings
 from tests.testsupport.factories.factories import (
     FitbitActivityFactory,
@@ -104,8 +105,8 @@ async def test_refresh_token_ok(
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    repo_user = await local_fitbit_repository.get_user_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid
+    repo_user = await local_fitbit_repository.get_user_by_lookup(
+        FitbitUserLookup(user_id=fitbit_user.oauth_userid)
     )
 
     # Then the access token is refreshed.
@@ -121,7 +122,7 @@ async def test_refresh_token_ok(
     # And the latest activity data is updated in the database
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=repo_user.identity.fitbit_userid,
+            user_lookup=repo_user.identity.user_lookup,
             type_id=activity_type_id,
         )
     )
@@ -207,8 +208,8 @@ async def test_refresh_token_fail(
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    repo_user = await local_fitbit_repository.get_user_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid
+    repo_user = await local_fitbit_repository.get_user_by_lookup(
+        FitbitUserLookup(user_id=fitbit_user.oauth_userid)
     )
 
     # Then the access token is not refreshed.
@@ -218,7 +219,7 @@ async def test_refresh_token_fail(
     # And no new activity data is updated in the database
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=repo_user.identity.fitbit_userid,
+            user_lookup=repo_user.identity.user_lookup,
             type_id=activity_type_id,
         )
     )
@@ -315,11 +316,12 @@ async def test_login_success(
     assert response.status_code == status.HTTP_200_OK
 
     # Verify that we have the expected data in the db
-    repo_user = await local_fitbit_repository.get_user_by_fitbit_userid(
-        "user123",
+    repo_user = await local_fitbit_repository.get_user_by_lookup(
+        FitbitUserLookup(user_id="user123")
     )
     assert repo_user.identity == UserIdentity(
         fitbit_userid="user123",
+        health_user_id=None,
         slack_alias="jdoe",
     )
 
@@ -395,8 +397,8 @@ async def test_logged_out(
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    repo_user = await local_fitbit_repository.get_user_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid
+    repo_user = await local_fitbit_repository.get_user_by_lookup(
+        FitbitUserLookup(user_id=fitbit_user.oauth_userid)
     )
 
     # Then the access token is not refreshed.
@@ -406,7 +408,7 @@ async def test_logged_out(
     # And no new activity data is updated in the database
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=repo_user.identity.fitbit_userid,
+            user_lookup=repo_user.identity.user_lookup,
             type_id=activity_type_id,
         )
     )

--- a/tests/routes/test_fitbit_routes.py
+++ b/tests/routes/test_fitbit_routes.py
@@ -90,8 +90,8 @@ async def test_sleep_notification(  # noqa: PLR0913
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
     # Then the last sleep data is updated in the database
-    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid,
+    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+        user_lookup=fitbit_user.lookup,
     )
     assert actual_last_sleep_data == scenario.expected_new_last_sleep_data
 
@@ -190,7 +190,7 @@ async def test_activity_notification(  # noqa PLR0913
     # Then the latest activity data is updated in the database
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=fitbit_user.oauth_userid,
+            user_lookup=fitbit_user.lookup,
             type_id=activity_type_id,
         )
     )
@@ -338,11 +338,11 @@ async def test_activity_notification_upserts_all_activities(
 
     # Then all activities are upserted
     activity_1 = await local_fitbit_repository.get_activity_by_user_and_log_id(
-        fitbit_userid=fitbit_user.oauth_userid,
+        user_lookup=fitbit_user.lookup,
         log_id="1001",
     )
     activity_2 = await local_fitbit_repository.get_activity_by_user_and_log_id(
-        fitbit_userid=fitbit_user.oauth_userid,
+        user_lookup=fitbit_user.lookup,
         log_id="1002",
     )
 

--- a/tests/routes/test_fitbit_routes_multiple_callbacks.py
+++ b/tests/routes/test_fitbit_routes_multiple_callbacks.py
@@ -123,8 +123,8 @@ async def test_multiple_sleep_notifications(  # noqa PLR0913
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
     # Then the last sleep data is updated in the database
-    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid,
+    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+        user_lookup=fitbit_user.lookup,
     )
     assert actual_last_sleep_data == SleepData(
         start_time=datetime.datetime(2023, 5, 13, 0, 40, 0),
@@ -187,8 +187,8 @@ async def test_multiple_sleep_notifications(  # noqa PLR0913
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
     # Then the last sleep data is updated in the database
-    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid,
+    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+        user_lookup=fitbit_user.lookup,
     )
     assert actual_last_sleep_data == SleepData(
         start_time=datetime.datetime(2023, 5, 14, 0, 40, 0),
@@ -261,8 +261,8 @@ async def test_duplicate_sleep_notification(
 
     # Then the last sleep data is updated in the database
     assert sleep_request.call_count == 1
-    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid,
+    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+        user_lookup=fitbit_user.lookup,
     )
     assert actual_last_sleep_data == scenario.expected_new_last_sleep_data
 
@@ -354,7 +354,7 @@ async def test_duplicate_activity_sequential_notification(
     assert activity_request.call_count == 1
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=fitbit_user.oauth_userid,
+            user_lookup=fitbit_user.lookup,
             type_id=activity_type_id,
         )
     )
@@ -463,7 +463,7 @@ async def test_duplicate_activity_parallel_notification(
     assert activity_request.call_count == 1
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=fitbit_user.oauth_userid,
+            user_lookup=fitbit_user.lookup,
             type_id=activity_type_id,
         )
     )

--- a/tests/tasks/test_fitbit_oauth.py
+++ b/tests/tasks/test_fitbit_oauth.py
@@ -14,6 +14,7 @@ from slackhealthbot.domain.localrepository.localfitbitrepository import (
     LocalFitbitRepository,
 )
 from slackhealthbot.domain.models.activity import ActivityData
+from slackhealthbot.domain.models.users import FitbitUserLookup
 from slackhealthbot.settings import Settings
 from slackhealthbot.tasks.fitbitpoll import Cache, do_poll
 from tests.testsupport.factories.factories import (
@@ -100,8 +101,8 @@ async def test_refresh_token_ok(  # noqa: PLR0913
             when=datetime.date(2023, 1, 23),
         )
 
-        repo_user = await local_fitbit_repository.get_user_by_fitbit_userid(
-            fitbit_userid=fitbit_user.oauth_userid
+        repo_user = await local_fitbit_repository.get_user_by_lookup(
+            FitbitUserLookup(user_id=fitbit_user.oauth_userid)
         )
 
         # Then the access token is refreshed.
@@ -117,7 +118,7 @@ async def test_refresh_token_ok(  # noqa: PLR0913
         # And the latest activity data is updated in the database
         repo_activity: ActivityData = (
             await local_fitbit_repository.get_latest_activity_by_user_and_type(
-                fitbit_userid=repo_user.identity.fitbit_userid,
+                user_lookup=repo_user.identity.user_lookup,
                 type_id=activity_type_id,
             )
         )
@@ -196,8 +197,8 @@ async def test_refresh_token_fail(  # noqa: PLR0913
             when=datetime.date(2023, 1, 23),
         )
 
-    repo_user = await local_fitbit_repository.get_user_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid
+    repo_user = await local_fitbit_repository.get_user_by_lookup(
+        FitbitUserLookup(user_id=fitbit_user.oauth_userid)
     )
 
     # Then the access token is not refreshed.
@@ -208,7 +209,7 @@ async def test_refresh_token_fail(  # noqa: PLR0913
     # And no new activity data is updated in the database
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=repo_user.identity.fitbit_userid,
+            user_lookup=repo_user.identity.user_lookup,
             type_id=activity_type_id,
         )
     )
@@ -307,8 +308,8 @@ async def test_logged_out(  # noqa: PLR0913
             when=datetime.date(2023, 1, 23),
         )
 
-    repo_user = await local_fitbit_repository.get_user_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid
+    repo_user = await local_fitbit_repository.get_user_by_lookup(
+        FitbitUserLookup(user_id=fitbit_user.oauth_userid)
     )
 
     # Then the access token is not refreshed.
@@ -318,7 +319,7 @@ async def test_logged_out(  # noqa: PLR0913
     # And no new activity data is updated in the database
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=repo_user.identity.fitbit_userid,
+            user_lookup=repo_user.identity.user_lookup,
             type_id=activity_type_id,
         )
     )

--- a/tests/tasks/test_fitbit_poll.py
+++ b/tests/tasks/test_fitbit_poll.py
@@ -93,8 +93,8 @@ async def test_fitbit_poll_sleep(  # noqa: PLR0913
         )
 
     # Then the last sleep data is updated in the database
-    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid,
+    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+        user_lookup=fitbit_user.lookup,
     )
     assert actual_last_sleep_data == scenario.expected_new_last_sleep_data
 
@@ -192,7 +192,7 @@ async def test_fitbit_poll_activity(  # noqa PLR0913
     # Then the latest activity data is updated in the database
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=fitbit_user.oauth_userid,
+            user_lookup=fitbit_user.lookup,
             type_id=activity_type_id,
         )
     )
@@ -274,15 +274,15 @@ async def test_schedule_fitbit_poll(  # noqa: PLR0913
     )
     await asyncio.sleep(1)
     # Then the last sleep data is updated in the database
-    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid,
+    actual_last_sleep_data = await local_fitbit_repository.get_sleep_by_user_lookup(
+        user_lookup=fitbit_user.lookup,
     )
     assert actual_last_sleep_data == sleep_scenario.expected_new_last_sleep_data
 
     # Then the latest activity data is updated in the database
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=fitbit_user.oauth_userid,
+            user_lookup=fitbit_user.lookup,
             type_id=55001,
         )
     )
@@ -386,11 +386,11 @@ async def test_fitbit_poll_activity_upserts_all_activities(
 
     # Then all activities are upserted
     activity_1 = await local_fitbit_repository.get_activity_by_user_and_log_id(
-        fitbit_userid=fitbit_user.oauth_userid,
+        user_lookup=fitbit_user.lookup,
         log_id="2001",
     )
     activity_2 = await local_fitbit_repository.get_activity_by_user_and_log_id(
-        fitbit_userid=fitbit_user.oauth_userid,
+        user_lookup=fitbit_user.lookup,
         log_id="2002",
     )
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -20,6 +20,7 @@ from slackhealthbot.domain.models.activity import (
     ActivityZone,
     ActivityZoneMinutes,
 )
+from slackhealthbot.domain.models.users import FitbitUserLookup
 from tests.testsupport.factories.factories import (
     FitbitActivityFactory,
     FitbitUserFactory,
@@ -91,8 +92,8 @@ async def test_fitbit_user_factory(
     assert isinstance(fitbit_user.oauth_expiration_date, datetime)
     assert isinstance(user, User)
 
-    repo_user = await local_fitbit_repository.get_user_by_fitbit_userid(
-        fitbit_userid=fitbit_user.oauth_userid
+    repo_user = await local_fitbit_repository.get_user_by_lookup(
+        FitbitUserLookup(user_id=fitbit_user.oauth_userid)
     )
     assert repo_user.oauth_data.oauth_access_token == fitbit_user.oauth_access_token
     assert repo_user.oauth_data.oauth_refresh_token == fitbit_user.oauth_refresh_token
@@ -117,7 +118,7 @@ async def test_fitbit_activity_factory(
     )
     repo_activity: ActivityData = (
         await local_fitbit_repository.get_latest_activity_by_user_and_type(
-            fitbit_userid=fitbit_user.oauth_userid,
+            user_lookup=fitbit_user.lookup,
             type_id=fitbit_activity.type_id,
         )
     )

--- a/tests/testsupport/factories/factories.py
+++ b/tests/testsupport/factories/factories.py
@@ -63,6 +63,7 @@ class FitbitUserFactory(SQLAlchemyModelFactory):
     oauth_expiration_date = Faker("date_time")
     latest_activities = RelatedFactoryList(FitbitActivityFactory, "fitbit_user", size=0)
     fitbit_user_id = LazyAttribute(lambda o: o.oauth_userid)
+    health_user_id = None
 
 
 class UserFactory(SQLAlchemyModelFactory):

--- a/tests/testsupport/factories/factories.py
+++ b/tests/testsupport/factories/factories.py
@@ -1,6 +1,13 @@
 import datetime as dt
 
-from factory import Faker, RelatedFactoryList, SelfAttribute, Sequence, SubFactory
+from factory import (
+    Faker,
+    LazyAttribute,
+    RelatedFactoryList,
+    SelfAttribute,
+    Sequence,
+    SubFactory,
+)
 from factory.alchemy import SQLAlchemyModelFactory
 
 from slackhealthbot.data.database.models import (
@@ -55,6 +62,7 @@ class FitbitUserFactory(SQLAlchemyModelFactory):
     oauth_userid = Faker("pystr")
     oauth_expiration_date = Faker("date_time")
     latest_activities = RelatedFactoryList(FitbitActivityFactory, "fitbit_user", size=0)
+    fitbit_user_id = LazyAttribute(lambda o: o.oauth_userid)
 
 
 class UserFactory(SQLAlchemyModelFactory):


### PR DESCRIPTION
Previously, the `oauth_user_id` was the user's fitbit user id.

With google authentication, the users will have 3 ids:
* oauth user id
* legacy fitbit user id (if applicable, seems to always be there even with a new fitbit account)
* health id: identifies the user for health data.

Changes:
* Add new fitbit user columns `fitbit_user_id` and `health_user_id`
* Adjust all user lookups to:
 - Lookup by `oauth_user_id` when it's related to oauth
 - Lookup by a new `UserLookup` union type, for identifying users for health data. This union is used to specify either a legacy fitbit user id, or a new health user id.

Issue:
* #125