### PR TITLE
Fix various issues with Google Health integration.

### DIFF
--- a/slackhealthbot/admin/models.py
+++ b/slackhealthbot/admin/models.py
@@ -76,7 +76,7 @@ class FitbitUserAdmin(ModelView, model=FitbitUser):
 class FitbitActivityAdmin(ModelView, model=FitbitActivity):
     form_include_pk = True
     column_default_sort = [
-        (FitbitActivity.created_at, True),
+        (FitbitActivity.logged_at, True),
     ]
 
 

--- a/slackhealthbot/domain/usecases/google/usecase_login_user.py
+++ b/slackhealthbot/domain/usecases/google/usecase_login_user.py
@@ -40,22 +40,22 @@ async def _upsert_user(
             FitbitUserLookup(user_id=health_ids.fitbit_user_id),
         )
 
-    # Matching legacy fitbit user.
+    # Matching legacy fitbit user which hasn't yet logged in with Google Health.
     # Update its oauth fields, looking up by their legacy fitbit user id
     # and then updating the oauth_userid to now be the google oauth user id.
-    if user_identity:
+    if user_identity and not user_identity.health_user_id:
         await local_repo.update_oauth_data(
             oauth_userid=health_ids.fitbit_user_id,
             oauth_data=oauth_fields,
         )
 
     # No matching legacy fitbit user.
-    # See if we have a google-only user.
+    # See if we have a google user.
     else:
         user_identity = await local_repo.get_user_identity(
             HealthUserLookup(user_id=health_ids.health_user_id)
         )
-        # Found existing google-only user.
+        # Found existing google user.
         # Update their oauth info (their oauth_userid won't change)
         if user_identity:
             await local_repo.update_oauth_data(

--- a/slackhealthbot/remoteservices/api/google/activityapi.py
+++ b/slackhealthbot/remoteservices/api/google/activityapi.py
@@ -17,15 +17,15 @@ DurationS = Annotated[int, BeforeValidator(parse_seconds_duration)]
 
 
 class TimeInHeartRateZones(BaseModel):
-    lightTime: DurationS
-    moderateTime: DurationS
-    vigorousTime: DurationS
-    peakTime: DurationS
+    lightTime: DurationS | None = None
+    moderateTime: DurationS | None = None
+    vigorousTime: DurationS | None = None
+    peakTime: DurationS | None = None
 
 
 class MetricsSummary(BaseModel):
     caloriesKcal: float
-    heartRateZoneDurations: TimeInHeartRateZones
+    heartRateZoneDurations: TimeInHeartRateZones | None = None
     distanceMillimeters: int | None = None
     model_config = ConfigDict(extra="allow")
 

--- a/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
+++ b/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
@@ -90,7 +90,7 @@ def remote_service_activity_type(exercise: activityapi.Exercise) -> int:
     # a treadmill activity.
     # This is not very reliable. We'll have to revisit this when the Google apis become more stable.
     if exercise.exerciseType == "OTHER":
-        if exercise.displayName == "Tapis de course":
+        if exercise.displayName in ("Tapis de course", "Treadmill walk"):
             return 91064
     if exercise.exerciseType == "WALKING":
         return 90013

--- a/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
+++ b/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
@@ -100,6 +100,31 @@ def remote_service_activity_type(exercise: activityapi.Exercise) -> int:
     return 99999
 
 
+def _remote_time_in_heart_rate_zones_to_domain_activity_zone_minutes(
+    time_in_heart_rate_zones: activityapi.TimeInHeartRateZones | None,
+) -> list[ActivityZoneMinutes]:
+    if time_in_heart_rate_zones is None:
+        return []
+    result: list[ActivityZoneMinutes] = []
+    remote_attr_to_domain_enum = {
+        "peakTime": ActivityZone.PEAK,
+        "vigorousTime": ActivityZone.CARDIO,
+        "moderateTime": ActivityZone.FAT_BURN,
+        "lightTime": ActivityZone.OUT_OF_ZONE,
+    }
+    for remote_attr, domain_enum in remote_attr_to_domain_enum.items():
+        value_seconds = getattr(time_in_heart_rate_zones, remote_attr)
+        if value_seconds:
+            result.append(
+                ActivityZoneMinutes(
+                    zone=domain_enum,
+                    minutes=value_seconds // 60,
+                )
+            )
+
+    return result
+
+
 def remote_service_activity_to_domain_activity(
     data_point: activityapi.DataPoint,
 ) -> ActivityData:
@@ -112,28 +137,9 @@ def remote_service_activity_to_domain_activity(
         distance_km=data_point.exercise.metricsSummary.distanceMillimeters
         / (1000 * 1000),
         total_minutes=data_point.exercise.activeDuration / 60,
-        zone_minutes=[
-            ActivityZoneMinutes(
-                zone=ActivityZone.PEAK,
-                minutes=data_point.exercise.metricsSummary.heartRateZoneDurations.peakTime
-                // 60,
-            ),
-            ActivityZoneMinutes(
-                zone=ActivityZone.CARDIO,
-                minutes=data_point.exercise.metricsSummary.heartRateZoneDurations.vigorousTime
-                // 60,
-            ),
-            ActivityZoneMinutes(
-                zone=ActivityZone.FAT_BURN,
-                minutes=data_point.exercise.metricsSummary.heartRateZoneDurations.moderateTime
-                // 60,
-            ),
-            ActivityZoneMinutes(
-                zone=ActivityZone.OUT_OF_ZONE,
-                minutes=data_point.exercise.metricsSummary.heartRateZoneDurations.lightTime
-                // 60,
-            ),
-        ],
+        zone_minutes=_remote_time_in_heart_rate_zones_to_domain_activity_zone_minutes(
+            data_point.exercise.metricsSummary.heartRateZoneDurations,
+        ),
     )
 
 

--- a/slackhealthbot/settings.py
+++ b/slackhealthbot/settings.py
@@ -162,8 +162,8 @@ class Google(BaseModel):
     oauth_scopes: list[str] = [
         "openid",
         "https://www.googleapis.com/auth/googlehealth.profile.readonly",
-        "https://www.googleapis.com/auth/googlehealth.activity_and_fitness",
-        "https://www.googleapis.com/auth/googlehealth.sleep",
+        "https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly",
+        "https://www.googleapis.com/auth/googlehealth.sleep.readonly",
     ]
 
 

--- a/tests/routes/test_google_oauth.py
+++ b/tests/routes/test_google_oauth.py
@@ -75,10 +75,10 @@ class LoginScenario:
             ),
         ),
         LoginScenario(
-            id="fitbit + google user",
+            id="fitbit + google user (most recently google)",
             existing_slack_user=True,
             existing_fitbit_user_data={
-                "oauth_userid": "legacyfitbit123",
+                "oauth_userid": "googleuserid123",
                 "fitbit_user_id": "legacyfitbit123",
                 "health_user_id": "healthuser123",
             },

--- a/tests/routes/test_google_routes.py
+++ b/tests/routes/test_google_routes.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime as dt
 import json
 from typing import Any
@@ -194,9 +195,43 @@ async def test_sleep_notification(
     assert actual_slack_message == expected_slack_message
 
 
+@dataclasses.dataclass
+class HeartRateScenario:
+    id: str
+    remote_heart_rate_data: dict[str, str] | None
+    expected_zone_minutes: list[ActivityZoneMinutes]
+
+
 @pytest.mark.parametrize(
     argnames="data_type",
     argvalues=["exercise", "distance"],
+)
+@pytest.mark.parametrize(
+    ids=lambda s: s.id,
+    argnames="heart_rate_scenario",
+    argvalues=[
+        HeartRateScenario(
+            id="some heart rate data",
+            remote_heart_rate_data={
+                "heartRateZoneDurations": {
+                    "lightTime": "0s",
+                    "moderateTime": "63s",
+                    "vigorousTime": "0s",
+                },
+            },
+            expected_zone_minutes=[
+                ActivityZoneMinutes(
+                    zone=ActivityZone.FAT_BURN,
+                    minutes=1,
+                ),
+            ],
+        ),
+        HeartRateScenario(
+            id="no heart rate data",
+            remote_heart_rate_data={},
+            expected_zone_minutes=[],
+        ),
+    ],
 )
 @pytest.mark.asyncio
 async def test_exercise_notification(
@@ -207,6 +242,7 @@ async def test_exercise_notification(
     fitbit_user: FitbitUser,
     local_fitbit_repository: LocalFitbitRepository,
     settings: Settings,
+    heart_rate_scenario: HeartRateScenario,
 ):
     """
     Given a fitbit user
@@ -247,12 +283,7 @@ async def test_exercise_notification(
                                 "caloriesKcal": 23,
                                 "activeZoneMinutes": "0",
                                 "distanceMillimeters": 120715,
-                                "heartRateZoneDurations": {
-                                    "lightTime": "0s",
-                                    "moderateTime": "63s",
-                                    "vigorousTime": "0s",
-                                    "peakTime": "0s",
-                                },
+                                **heart_rate_scenario.remote_heart_rate_data,
                             },
                             "displayName": "Tapis de course",
                             "activeDuration": "1800s",
@@ -308,12 +339,7 @@ async def test_exercise_notification(
         total_minutes=30,
         calories=23,
         distance_km=pytest.approx(0.120715),
-        zone_minutes=[
-            ActivityZoneMinutes(
-                zone=ActivityZone.FAT_BURN,
-                minutes=1,
-            ),
-        ],
+        zone_minutes=heart_rate_scenario.expected_zone_minutes,
     )
 
     # And a message is posted to slack.


### PR DESCRIPTION
* Use correct Google Health scopes to read exercise and sleep data.
* Properly handle the case of a user who:
  - logged in with fitbit
  - logged in with google
  - logged in again with google
* Manage heart rate zone durations data being absent.
* Support "Treadmill walk" as an expected `display_name` to identify treadmill activities created from the mobile app.

Not related to google health:
* Sort activities by `logged_at` descending, by default, in the admin view.