### PR TITLE
Various fixes for the google health api.

### DIFF
--- a/slackhealthbot/remoteservices/api/google/activityapi.py
+++ b/slackhealthbot/remoteservices/api/google/activityapi.py
@@ -24,7 +24,7 @@ class TimeInHeartRateZones(BaseModel):
 
 
 class MetricsSummary(BaseModel):
-    caloriesKcal: float
+    caloriesKcal: float = 0
     heartRateZoneDurations: TimeInHeartRateZones | None = None
     distanceMillimeters: int | None = None
     model_config = ConfigDict(extra="allow")

--- a/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
+++ b/slackhealthbot/remoteservices/repositories/webapigooglerepository.py
@@ -83,15 +83,8 @@ class WebApiGoogleRepository(RemoteGoogleRepository):
 
 def remote_service_activity_type(exercise: activityapi.Exercise) -> int:
     # https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints#Exercise.ExerciseType
-    # WHY GOOGLE?
-    # Google has only a handful of exercise types, much less than the Fitbit api.
-    # "Treadmill" isn't one of them, unfortunately.
-    # Just by testing, we see that the displayName was "Tapis de course", for one account, for
-    # a treadmill activity.
-    # This is not very reliable. We'll have to revisit this when the Google apis become more stable.
-    if exercise.exerciseType == "OTHER":
-        if exercise.displayName in ("Tapis de course", "Treadmill walk"):
-            return 91064
+    if exercise.exerciseType in ("TREADMILL", "TREADMILL_WALK"):
+        return 91064
     if exercise.exerciseType == "WALKING":
         return 90013
     if exercise.exerciseType == "BIKING":

--- a/slackhealthbot/routers/google.py
+++ b/slackhealthbot/routers/google.py
@@ -125,7 +125,15 @@ async def google_oauth_webhook(
     )
 
 
-@router.post("/google-notification-webhook/")
+async def log_raw_request(request: Request):
+    body = await request.body()
+    logging.info(f"Incoming Request Body: {body.decode()}")
+
+
+@router.post(
+    "/google-notification-webhook/",
+    dependencies=[Depends(log_raw_request)],
+)
 @inject
 async def google_notification_webhook(
     notification: Notification,

--- a/tests/routes/test_google_routes.py
+++ b/tests/routes/test_google_routes.py
@@ -196,10 +196,12 @@ async def test_sleep_notification(
 
 
 @dataclasses.dataclass
-class HeartRateScenario:
+class MetricsSummaryScenario:
     id: str
-    remote_heart_rate_data: dict[str, str] | None
+    metrics_summary_data: dict[str, Any] | None
     expected_zone_minutes: list[ActivityZoneMinutes]
+    expected_calories: int
+    expected_distance_km: float
 
 
 @pytest.mark.parametrize(
@@ -208,11 +210,14 @@ class HeartRateScenario:
 )
 @pytest.mark.parametrize(
     ids=lambda s: s.id,
-    argnames="heart_rate_scenario",
+    argnames="scenario",
     argvalues=[
-        HeartRateScenario(
-            id="some heart rate data",
-            remote_heart_rate_data={
+        MetricsSummaryScenario(
+            id="some metrics summary data",
+            metrics_summary_data={
+                "caloriesKcal": 23,
+                "distanceMillimeters": 120715,
+                "activeZoneMinutes": "0",
                 "heartRateZoneDurations": {
                     "lightTime": "0s",
                     "moderateTime": "63s",
@@ -225,11 +230,15 @@ class HeartRateScenario:
                     minutes=1,
                 ),
             ],
+            expected_calories=23,
+            expected_distance_km=0.120715,
         ),
-        HeartRateScenario(
-            id="no heart rate data",
-            remote_heart_rate_data={},
+        MetricsSummaryScenario(
+            id="no metrics summary data",
+            metrics_summary_data={},
             expected_zone_minutes=[],
+            expected_calories=0,
+            expected_distance_km=0,
         ),
     ],
 )
@@ -242,7 +251,7 @@ async def test_exercise_notification(
     fitbit_user: FitbitUser,
     local_fitbit_repository: LocalFitbitRepository,
     settings: Settings,
-    heart_rate_scenario: HeartRateScenario,
+    scenario: MetricsSummaryScenario,
 ):
     """
     Given a fitbit user
@@ -279,12 +288,7 @@ async def test_exercise_notification(
                                 "endUtcOffset": "7200s",
                             },
                             "exerciseType": "WALKING",
-                            "metricsSummary": {
-                                "caloriesKcal": 23,
-                                "activeZoneMinutes": "0",
-                                "distanceMillimeters": 120715,
-                                **heart_rate_scenario.remote_heart_rate_data,
-                            },
+                            "metricsSummary": scenario.metrics_summary_data,
                             "displayName": "Tapis de course",
                             "activeDuration": "1800s",
                         },
@@ -337,9 +341,9 @@ async def test_exercise_notification(
         type_id=90013,
         logged_at=dt.datetime(2026, 4, 4, 22, 53),
         total_minutes=30,
-        calories=23,
-        distance_km=pytest.approx(0.120715),
-        zone_minutes=heart_rate_scenario.expected_zone_minutes,
+        calories=scenario.expected_calories,
+        distance_km=pytest.approx(scenario.expected_distance_km),
+        zone_minutes=scenario.expected_zone_minutes,
     )
 
     # And a message is posted to slack.


### PR DESCRIPTION
* Support an empty metricsSummary block.
* Log the request body of the google webhook, so we can understand why we're getting 422 errors.
* Support TREADMILL and TREADMILL_WALK exercise types.