### PR TITLE
fix(googlehealth): Support a Google webhook notification payload which is an array.

### DIFF
--- a/slackhealthbot/routers/google.py
+++ b/slackhealthbot/routers/google.py
@@ -86,7 +86,11 @@ class VerificationNotification(BaseModel):
 
 # Google can call our webhook route with either exercise/sleep data, or to verify
 # that the route is correctly configured.
-Notification = DataNotification | VerificationNotification
+# The webhook documentation indicates that a data notification is an object,
+# but in reality we observe that it's an array containing one object.
+# Support both.
+# https://developers.google.com/health/webhooks
+Notification = list[DataNotification] | DataNotification | VerificationNotification
 
 # End models for the webhook notification request body
 
@@ -160,9 +164,13 @@ async def google_notification_webhook(
     # https://developers.google.com/health/webhooks#endpoint_verification
     if isinstance(notification, VerificationNotification):
         return Response(status_code=status.HTTP_200_OK)
-    # else: notification is a DataNotification
-
-    data_notification: DataNotification = notification
+    if isinstance(notification, list):
+        if len(notification) == 0:
+            logging.warning("Received empty data notificaion")
+            return Response(status_code=status.HTTP_200_OK)
+        data_notification: DataNotification = notification[0]
+    else:  # notification is a DataNotification
+        data_notification = notification
 
     # Cases we don't handle:
     if (

--- a/tests/routes/test_google_routes.py
+++ b/tests/routes/test_google_routes.py
@@ -204,10 +204,12 @@ class MetricsSummaryScenario:
     expected_distance_km: float
 
 
-@pytest.mark.parametrize(
-    argnames="data_type",
-    argvalues=["exercise", "distance"],
-)
+@dataclasses.dataclass
+class WebhookPayloadScenario:
+    id: str
+    webhook_payload: list[dict[str, Any]] | dict[str, Any]
+
+
 @pytest.mark.parametrize(
     ids=lambda s: s.id,
     argnames="scenario",
@@ -242,16 +244,98 @@ class MetricsSummaryScenario:
         ),
     ],
 )
+@pytest.mark.parametrize(
+    ids=lambda s: s.id,
+    argnames="webhook_payload_scenario",
+    argvalues=[
+        WebhookPayloadScenario(
+            id="list exercise",
+            webhook_payload=[
+                {
+                    "data": {
+                        "healthUserId": "123",
+                        "operation": "UPSERT",
+                        "dataType": "exercise",
+                        "intervals": [
+                            {
+                                "civilIso8601TimeInterval": {
+                                    "startTime": "2026-04-11T17:29:00.040495",
+                                    "endTime": "2026-04-011T17:34:22.040495",
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+        ),
+        WebhookPayloadScenario(
+            id="list distance",
+            webhook_payload=[
+                {
+                    "data": {
+                        "healthUserId": "123",
+                        "operation": "UPSERT",
+                        "dataType": "distance",
+                        "intervals": [
+                            {
+                                "civilIso8601TimeInterval": {
+                                    "startTime": "2026-04-11T17:29:00.040495",
+                                    "endTime": "2026-04-011T17:34:22.040495",
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+        ),
+        WebhookPayloadScenario(
+            id="dict exercise",
+            webhook_payload={
+                "data": {
+                    "healthUserId": "123",
+                    "operation": "UPSERT",
+                    "dataType": "exercise",
+                    "intervals": [
+                        {
+                            "civilIso8601TimeInterval": {
+                                "startTime": "2026-04-11T17:29:00.040495",
+                                "endTime": "2026-04-011T17:34:22.040495",
+                            },
+                        }
+                    ],
+                },
+            },
+        ),
+        WebhookPayloadScenario(
+            id="dict distance",
+            webhook_payload={
+                "data": {
+                    "healthUserId": "123",
+                    "operation": "UPSERT",
+                    "dataType": "distance",
+                    "intervals": [
+                        {
+                            "civilIso8601TimeInterval": {
+                                "startTime": "2026-04-11T17:29:00.040495",
+                                "endTime": "2026-04-011T17:34:22.040495",
+                            },
+                        }
+                    ],
+                },
+            },
+        ),
+    ],
+)
 @pytest.mark.asyncio
 async def test_exercise_notification(
     client: TestClient,
-    data_type: str,
     respx_mock: MockRouter,
     authorization_headers: dict[str, str],
     fitbit_user: FitbitUser,
     local_fitbit_repository: LocalFitbitRepository,
     settings: Settings,
     scenario: MetricsSummaryScenario,
+    webhook_payload_scenario: WebhookPayloadScenario,
 ):
     """
     Given a fitbit user
@@ -310,20 +394,7 @@ async def test_exercise_notification(
         response = client.post(
             "/google-notification-webhook/",
             headers=authorization_headers,
-            json={
-                "data": {
-                    "healthUserId": "123",
-                    "operation": "UPSERT",
-                    "dataType": data_type,
-                    "intervals": [
-                        {
-                            "civilIso8601TimeInterval": {
-                                "startTime": "2026-04-11T17:29:00",
-                            },
-                        }
-                    ],
-                }
-            },
+            json=webhook_payload_scenario.webhook_payload,
         )
 
     # Then the webhook returns a successful response,


### PR DESCRIPTION


The Google health api documentation indicates that the webhook notification format is an object: https://developers.google.com/health/webhooks

However, we see that we're actually receving an array of one item. This one item matches the documented notification format.